### PR TITLE
TableView of Feed Items refreshing incorrectly

### DIFF
--- a/media/iphone/Classes/FeedDetailViewController.m
+++ b/media/iphone/Classes/FeedDetailViewController.m
@@ -872,7 +872,7 @@
     self.feedPage = 1;
     self.pageFetching = YES;
     self.pageRefreshing = YES;
-    [self.storyTitlesTable reloadData];
+//    [self.storyTitlesTable reloadData];
     [storyTitlesTable scrollRectToVisible:CGRectMake(0, 0, 1, 1) animated:YES];
 }
 
@@ -883,7 +883,7 @@
     [pull finishedLoading];
     self.pageRefreshing = NO;
     [self renderStories:[results objectForKey:@"stories"]];
-    
+    [self.storyTitlesTable reloadData];
     [results release];
 }
 


### PR DESCRIPTION
When the pull to refresh of the table view was activated, all of the items visible in the view would disappear. This created a jarring effect on the user, and is a different than usual implementations of pull to refresh. Think about TweetBot, for example: when you pull to refresh, all of the tweets you can currently see don't disappear.

This was fixed really ridiculously easily by moving the call for the table to refresh its data from the pulling function to the results received function. 
