### PR TITLE
Change OPML export filename to use ISO date format

### DIFF
--- a/apps/feed_import/views.py
+++ b/apps/feed_import/views.py
@@ -54,7 +54,7 @@ def opml_export(request):
     
     response = HttpResponse(opml, mimetype='text/xml')
     response['Content-Disposition'] = 'attachment; filename=NewsBlur Subscriptions - %s' % (
-        now.strftime('%d %B %Y')
+        now.strftime('%Y-%m-%d')
     )
     
     return response


### PR DESCRIPTION
This allows one to have multiple export files that will then sort correctly on the filesystem.
