### PR TITLE
document keyboard shortcut to add site/folder

### DIFF
--- a/media/js/newsblur/reader/reader_keyboard.js
+++ b/media/js/newsblur/reader/reader_keyboard.js
@@ -270,6 +270,14 @@ NEWSBLUR.ReaderKeyboard.prototype = {
                     '?'
                 ])
               ])
+            ]),
+            $.make('div', { className: 'NB-keyboard-group' }, [
+              $.make('div', { className: 'NB-keyboard-shortcut NB-last' }, [
+                $.make('div', { className: 'NB-keyboard-shortcut-explanation' }, 'Add Site/Folder'),
+                $.make('div', { className: 'NB-keyboard-shortcut-key' }, [
+                    'a'
+                ])
+              ])
             ])
         ]);
     },


### PR DESCRIPTION
Hey. I don't know if you even accept pull requests, but I mentioned a shortcut to add a site would be nice as a keyboard shortcut a few months ago on the survey you did on the newsblur blog and just discovered it already exists by accident a few days ago. I will be honest and say I haven't tested this change but I figured at the very least it would draw your attention to the fact that this shortcut isn't documented on the keyboard shortcut modal and I think it should be since I found it very useful. If you'd like me to change this at all I'm happy to spend a little more time doing it properly - for now I basically just copied the formatting of the other items and hoped for the best. I don't know if the fact that there's only one item on this new line will break any formatting; maybe there's another undocumented shortcut you could add as well to even it out?
