### PR TITLE
S3 and digital ocean packages are now only required if you use them

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -22,7 +22,7 @@ def sudoEasyInstall(*args):
     sudo('easy_install -U %s' % args)
 
 def runGitClone(src, dst = None):
-    cmd = 'git clone %s' % (src,)
+    cmd = 'git clone --depth 1 %s' % (src,)
 
     if(not dst is None):
         cmd += ' ' + dst


### PR DESCRIPTION
S3 and digital ocean dependencies are now only required if you use the
S3 or digital ocean deployment functions.

I think putting the dependencies into the functions makes it easier to customize the files as you don't have to modify so much in fabfile.py
