### PR TITLE
Restore default pre/code block styling

### DIFF
--- a/media/css/reader.css
+++ b/media/css/reader.css
@@ -1901,10 +1901,6 @@ background: transparent;
 .NB-feed-story .NB-feed-story-content div {
     max-width: 100%;
 }
-.NB-feed-story .NB-feed-story-content pre,
-.NB-feed-story .NB-feed-story-content code {
-    white-space: normal;
-}
 .NB-feed-story .NB-feed-story-content img {
   max-width: 100% !important;
   width: auto;


### PR DESCRIPTION
Fixes #85.

To reproduce select a `.NB-feed-story-content` element in web developer tools and replace its content with this html:

```
<pre><code class="bash">Sujet: Courte description des changements de ce patch <span class="o">(</span>que fait ce patch ?<span class="o">)</span>

Une description si nécessaire plus détaillée du pourquoi, problème rencontré...
Comme pour les emails, la description ne devrait pas dépasser 80 caractères.

On peut mettre le ticket ou numéro de ticket sur une autre ligne.

Si le commit a été relu ou fait par plusieurs développeurs, il y a le mot clef
<span class="sb">`</span>Signed-off-by:<span class="sb">`</span> <span class="o"> (</span><span class="sb">`</span>--signoff<span class="sb">`</span><span class="o">)</span>. Ou encore <span class="sb">`</span>Reported-by:<span class="sb">`</span> pour les bugs reportés.
</code></pre>
```

This will show the line wrapping of the content. The formatting of the original can be seen here: http://drupalsun.com/node/33803

The patch simply removes the styling of `pre` and `code` elements to have normal `white-space`.
