### PR TITLE
Adds content_type header to /social/rss/ requests

### DIFF
--- a/apps/social/views.py
+++ b/apps/social/views.py
@@ -1208,7 +1208,7 @@ def shared_stories_rss_feed(request, user_id, username):
         user.username,
         request.META['HTTP_USER_AGENT'][:24]
     ))
-    return HttpResponse(rss.writeString('utf-8'))
+    return HttpResponse(rss.writeString('utf-8'), content_type='application/rss+xml')
 
 @required_params('user_id')
 @json.json_view


### PR DESCRIPTION
I noticed that /social/rss/ requests return `text/html`, even though they're RSS feeds. I added in a content_type to the HttpResponse line to make it correct.
