### PR TITLE
Fixed API docs for /reader/river_stories

### DIFF
--- a/templates/static/api.yml
+++ b/templates/static/api.yml
@@ -229,6 +229,11 @@
           optional: true
           default: newest
           example: oldest
+        - key: read_filter
+          desc: "Show all stories or only unread stories"
+          optional: true
+          default: unread
+          example: all
             
     - url: /reader/mark_story_as_read
       method: POST


### PR DESCRIPTION
read_filter on /reader/river_stories defaults to unread, however the parameter wasn't even documented before on this endpoint.
