### PR TITLE
Configurable trim_feed handling

### DIFF
--- a/apps/rss_feeds/models.py
+++ b/apps/rss_feeds/models.py
@@ -967,44 +967,35 @@ class Feed(models.Model):
             self.save_popular_authors(feed_authors=feed_authors[:-1])
             
     def trim_feed(self, verbose=False):
-        trim_cutoff = 500
-        if self.active_subscribers <= 0:
-            trim_cutoff = 25
-        elif self.num_subscribers <= 10 or self.active_premium_subscribers <= 1:
-            trim_cutoff = 100
-        elif self.num_subscribers <= 30  or self.active_premium_subscribers <= 3:
-            trim_cutoff = 200
-        elif self.num_subscribers <= 50  or self.active_premium_subscribers <= 5:
-            trim_cutoff = 300
-        elif self.num_subscribers <= 100 or self.active_premium_subscribers <= 10:
-            trim_cutoff = 350
-        elif self.num_subscribers <= 150 or self.active_premium_subscribers <= 15:
-            trim_cutoff = 400
-        elif self.num_subscribers <= 200 or self.active_premium_subscribers <= 20:
-            trim_cutoff = 450
-            
+        if not settings.TRIM_STORIES:
+            return
+
         stories = MStory.objects(
             story_feed_id=self.pk,
         ).order_by('-story_date')
-        
-        if stories.count() > trim_cutoff:
-            logging.debug('   ---> [%-30s] ~FBFound %s stories. Trimming to ~SB%s~SN...' %
-                          (unicode(self)[:30], stories.count(), trim_cutoff))
+
+        trim_cutoff = settings.TRIM_STORIES_KEEP_NUM
+        stories_count = stories.count()
+        if stories_count > trim_cutoff:
+            story_trim_date_bydate = datetime.datetime.utcnow() - datetime.timedelta(days=settings.TRIM_STORIES_KEEP_DAYS)
             try:
-                story_trim_date = stories[trim_cutoff].story_date
+                story_trim_date_bycount = stories[trim_cutoff].story_date
             except IndexError, e:
                 logging.debug(' ***> [%-30s] ~BRError trimming feed: %s' % (unicode(self)[:30], e))
                 return
-                
-            extra_stories = MStory.objects(story_feed_id=self.pk, 
+            story_trim_date = story_trim_date_bycount if story_trim_date_bycount and story_trim_date_bycount < story_trim_date_bydate else story_trim_date_bydate
+            extra_stories = MStory.objects(story_feed_id=self.pk,
                                            story_date__lte=story_trim_date)
             extra_stories_count = extra_stories.count()
-            for story in extra_stories:
-                story.delete()
-            if verbose:
-                existing_story_count = MStory.objects(story_feed_id=self.pk).count()
-                print "Deleted %s stories, %s left." % (extra_stories_count,
-                                                        existing_story_count)
+            if extra_stories_count > 0:
+                logging.debug('   ---> [%-30s] ~FBFound %s (of %s) stories older than ~SB%s~SN...' %
+                              (unicode(self)[:30], extra_stories_count, stories_count, story_trim_date))
+                for story in extra_stories:
+                    story.delete()
+                if verbose:
+                    existing_story_count = MStory.objects(story_feed_id=self.pk).count()
+                    print "Deleted %s stories, %s left." % (extra_stories_count,
+                                                            existing_story_count)
 
     @staticmethod
     def clean_invalid_ids():

--- a/settings.py
+++ b/settings.py
@@ -22,7 +22,7 @@ SERVER_NAME  = 'newsblur'
 SERVER_EMAIL = 'server@newsblur.com'
 HELLO_EMAIL  = 'hello@newsblur.com'
 NEWSBLUR_URL = 'http://www.newsblur.com'
-SECRET_KEY            = 'YOUR_SECRET_KEY'
+SECRET_KEY   = 'YOUR_SECRET_KEY'
 
 # ===========================
 # = Directory Declaractions =
@@ -190,6 +190,10 @@ LOGGING = {
 
 DAYS_OF_UNREAD          = 14
 SUBSCRIBER_EXPIRE       = 2
+
+TRIM_STORIES            = True    # Purge old articles from database?
+TRIM_STORIES_KEEP_DAYS  = 180     # Keep at least articles that are younger than 180 days old
+TRIM_STORIES_KEEP_NUM   = 100     # Keep at least 100 articles per feed
 
 AUTH_PROFILE_MODULE     = 'newsblur.UserProfile'
 TEST_DATABASE_COLLATION = 'utf8_general_ci'


### PR DESCRIPTION
(Fixes #120)

Introduce additional flags in settings.py for controlling how feed-trimming (purging old articles) behaves.

In `settings.py`, add a few new flags:
- `TRIM_STORIES` is the master enabled/disabled switch. Enabled by default.
- `TRIM_STORIES_KEEP_DAYS` is the minimum # of days to keep articles around for. I choose 180 days as the default.
- `TRIM_STORIES_KEEP_NUM` is the minimum # of articles to keep per feed. I choose 100 stories as the default.

In `apps/rss_feeds/models.py` (`trim_feed`), respect new `TRIM_STORIES*` flags. If `TRIM_STORIES` is enabled, if there are over `TRIM_STORIES_KEEP_NUM` stories in a given feed, pick a threshold-date for the purge by picking the lesser of the two dates between the date of the `TRIM_STORIES_KEEP_NUM`'th story in the feed versus the `Now`-`TRIM_STORIES_KEEP_DAYS` date. In other words, ensure that we keep at least `TRIM_STORIES_KEEP_DAYS` worth of articles and at least `TRIM_STORIES_KEEP_NUM` worth of articles.
