### PR TITLE
Fix force close for Android when non-premium users try to add fees via auto_complete

### DIFF
--- a/media/android/NewsBlur/src/com/newsblur/activity/SearchForFeeds.java
+++ b/media/android/NewsBlur/src/com/newsblur/activity/SearchForFeeds.java
@@ -1,19 +1,17 @@
 package com.newsblur.activity;
 
-import java.util.ArrayList;
-
 import android.app.SearchManager;
 import android.content.Intent;
 import android.os.Bundle;
 import android.support.v4.app.DialogFragment;
 import android.support.v4.app.LoaderManager.LoaderCallbacks;
 import android.support.v4.content.Loader;
-import android.util.Log;
 import android.view.View;
 import android.widget.AdapterView;
 import android.widget.AdapterView.OnItemClickListener;
 import android.widget.ListView;
 import android.widget.TextView;
+import android.widget.Toast;
 
 import com.actionbarsherlock.app.SherlockFragmentActivity;
 import com.actionbarsherlock.view.Menu;
@@ -24,12 +22,12 @@ import com.newsblur.R;
 import com.newsblur.domain.FeedResult;
 import com.newsblur.fragment.AddFeedFragment;
 import com.newsblur.network.SearchAsyncTaskLoader;
+import com.newsblur.network.SearchLoaderResponse;
 
-public class SearchForFeeds extends SherlockFragmentActivity implements LoaderCallbacks<ArrayList<FeedResult>>, OnItemClickListener {
+public class SearchForFeeds extends SherlockFragmentActivity implements LoaderCallbacks<SearchLoaderResponse>, OnItemClickListener {
 	private static final int LOADER_TWITTER_SEARCH = 0x01;
-	private Menu menu;
 	private ListView resultsList;
-	private Loader<ArrayList<FeedResult>> searchLoader;
+	private Loader<SearchLoaderResponse> searchLoader;
 	private FeedSearchResultAdapter adapter;
 
 	@Override
@@ -57,7 +55,6 @@ public class SearchForFeeds extends SherlockFragmentActivity implements LoaderCa
 		super.onCreateOptionsMenu(menu);
 		MenuInflater inflater = getSupportMenuInflater();
 		inflater.inflate(R.menu.search, menu);
-		this.menu = menu;
 		return true;
 	}
 
@@ -94,20 +91,25 @@ public class SearchForFeeds extends SherlockFragmentActivity implements LoaderCa
 	}
 
 	@Override
-	public Loader<ArrayList<FeedResult>> onCreateLoader(int loaderId, Bundle bundle) {
+	public Loader<SearchLoaderResponse> onCreateLoader(int loaderId, Bundle bundle) {
 		String searchTerm = bundle.getString(SearchAsyncTaskLoader.SEARCH_TERM);
 		return new SearchAsyncTaskLoader(this, searchTerm);
 	}
 
 	@Override
-	public void onLoadFinished(Loader<ArrayList<FeedResult>> loader, ArrayList<FeedResult> results) {
-		adapter = new FeedSearchResultAdapter(this, 0, 0, results);
-		resultsList.setAdapter(adapter);
+	public void onLoadFinished(Loader<SearchLoaderResponse> loader, SearchLoaderResponse results) {
 		setSupportProgressBarIndeterminateVisibility(false);
+		if(!results.hasError()) {
+			adapter = new FeedSearchResultAdapter(this, 0, 0, results.getResults());
+			resultsList.setAdapter(adapter);
+		} else {
+			String message = results.getErrorMessage() == null ? "Error" : results.getErrorMessage();
+			Toast.makeText(this, message, Toast.LENGTH_SHORT).show();
+		}
 	}
 
 	@Override
-	public void onLoaderReset(Loader<ArrayList<FeedResult>> loader) {
+	public void onLoaderReset(Loader<SearchLoaderResponse> loader) {
 		
 	}
 

--- a/media/android/NewsBlur/src/com/newsblur/network/BaseLoaderResponse.java
+++ b/media/android/NewsBlur/src/com/newsblur/network/BaseLoaderResponse.java
@@ -1,0 +1,29 @@
+package com.newsblur.network;
+
+public abstract class BaseLoaderResponse {
+
+	protected String errorMessage;
+	protected boolean hasError;
+
+	public BaseLoaderResponse() {
+	}
+
+	/**
+	 * Use if the loader had a problem that needs to be communicated back to
+	 * user
+	 * 
+	 * @param errorMessage
+	 */
+	public BaseLoaderResponse(String errorMessage) {
+		this.errorMessage = errorMessage;
+		this.hasError = true;
+	}
+
+	public String getErrorMessage() {
+		return errorMessage;
+	}
+
+	public boolean hasError() {
+		return hasError;
+	}
+}

--- a/media/android/NewsBlur/src/com/newsblur/network/SearchAsyncTaskLoader.java
+++ b/media/android/NewsBlur/src/com/newsblur/network/SearchAsyncTaskLoader.java
@@ -7,7 +7,7 @@ import android.support.v4.content.AsyncTaskLoader;
 
 import com.newsblur.domain.FeedResult;
 
-public class SearchAsyncTaskLoader extends AsyncTaskLoader<ArrayList<FeedResult>> {
+public class SearchAsyncTaskLoader extends AsyncTaskLoader<SearchLoaderResponse> {
 
 	public static final String SEARCH_TERM = "searchTerm";
 	
@@ -21,13 +21,18 @@ public class SearchAsyncTaskLoader extends AsyncTaskLoader<ArrayList<FeedResult>
 	}
 
 	@Override
-	public ArrayList<FeedResult> loadInBackground() {
-		ArrayList<FeedResult> list = new ArrayList<FeedResult>();
-		for (FeedResult result : apiManager.searchForFeed(searchTerm)) {
-			list.add(result);
+	public SearchLoaderResponse loadInBackground() {
+		SearchLoaderResponse response;
+		try {
+			ArrayList<FeedResult> list = new ArrayList<FeedResult>();
+			for (FeedResult result : apiManager.searchForFeed(searchTerm)) {
+				list.add(result);
+			}
+			response = new SearchLoaderResponse(list);
+		} catch (ServerErrorException ex) {
+			response = new SearchLoaderResponse(ex.getMessage());
 		}
-		
-		return list;
+		return response;
 	}
 
 }

--- a/media/android/NewsBlur/src/com/newsblur/network/SearchLoaderResponse.java
+++ b/media/android/NewsBlur/src/com/newsblur/network/SearchLoaderResponse.java
@@ -1,0 +1,30 @@
+package com.newsblur.network;
+
+import java.util.ArrayList;
+
+import com.newsblur.domain.FeedResult;
+
+public class SearchLoaderResponse extends BaseLoaderResponse {
+
+	private ArrayList<FeedResult> results;
+
+	/**
+	 * Use to indicate there was a problem w/ the search
+	 * 
+	 * @param errorMessage
+	 */
+	public SearchLoaderResponse(String errorMessage) {
+		super(errorMessage);
+		results = new ArrayList<FeedResult>(0);
+	}
+	
+	public SearchLoaderResponse(ArrayList<FeedResult> results) {
+		this.results = results;
+	}
+	
+	public ArrayList<FeedResult> getResults() {
+		return results;
+	}
+
+
+}

--- a/media/android/NewsBlur/src/com/newsblur/network/ServerErrorException.java
+++ b/media/android/NewsBlur/src/com/newsblur/network/ServerErrorException.java
@@ -1,0 +1,8 @@
+package com.newsblur.network;
+
+public class ServerErrorException extends Exception {
+	
+	public ServerErrorException(String errorMessage) {
+		super(errorMessage);
+	}
+}

--- a/media/android/NewsBlur/src/com/newsblur/network/domain/Message.java
+++ b/media/android/NewsBlur/src/com/newsblur/network/domain/Message.java
@@ -1,0 +1,11 @@
+package com.newsblur.network.domain;
+
+public class Message {
+
+	// {"message": "Overloaded, no autocomplete results.", "code": -1, "authenticated": true, "result": "ok"}
+	
+	public String message;
+	public int code;
+	public boolean authenticated;
+	public String result; 
+}


### PR DESCRIPTION
For stability reasons Sam temporarily turned off the auto_complete API call for non-premium users.  The API was returning a server 'Message' response that wasn't parsable by gson and it threw error which force closed the app.  We can now handle both the expected feed list response and the 'Message' response.  The text within the message will now be shown to the user to provide greater context as to why the request failed.
