### PR TITLE
Android: Follow Recommended 2-step Sync on Load

### DIFF
--- a/media/android/NewsBlur/src/com/newsblur/activity/ItemsList.java
+++ b/media/android/NewsBlur/src/com/newsblur/activity/ItemsList.java
@@ -73,8 +73,6 @@ public abstract class ItemsList extends SherlockFragmentActivity implements Sync
 		return false;
 	}
 	
-	
-
 	@Override
 	public void updateAfterSync() {
 		if (itemListFragment != null) {
@@ -83,6 +81,15 @@ public abstract class ItemsList extends SherlockFragmentActivity implements Sync
 			Log.e(TAG, "Error updating list as it doesn't exist.");
 		}
 		setSupportProgressBarIndeterminateVisibility(false);
+	}
+
+	@Override
+	public void updatePartialSync() {
+		if (itemListFragment != null) {
+			itemListFragment.hasUpdated();
+		} else {
+			Log.e(TAG, "Error updating list as it doesn't exist.");
+		}
 	}
 
 	@Override

--- a/media/android/NewsBlur/src/com/newsblur/activity/Reading.java
+++ b/media/android/NewsBlur/src/com/newsblur/activity/Reading.java
@@ -179,6 +179,13 @@ public abstract class Reading extends SherlockFragmentActivity implements OnPage
 		checkStoryCount(pager.getCurrentItem());
 	}
 
+	@Override
+	public void updatePartialSync() {
+		stories.requery();
+		readingAdapter.notifyDataSetChanged();
+		checkStoryCount(pager.getCurrentItem());
+	}
+
 	public abstract void checkStoryCount(int position);
 
 	@Override

--- a/media/android/NewsBlur/src/com/newsblur/fragment/SyncUpdateFragment.java
+++ b/media/android/NewsBlur/src/com/newsblur/fragment/SyncUpdateFragment.java
@@ -11,7 +11,8 @@ import com.newsblur.service.DetachableResultReceiver.Receiver;
 import com.newsblur.service.SyncService;
 
 public class SyncUpdateFragment extends Fragment implements Receiver {
-		public static final String TAG = "SyncUpdateFragment";
+
+        public static final String TAG = SyncUpdateFragment.class.getName();
 		public DetachableResultReceiver receiver;
 		public boolean syncRunning = false;
 
@@ -40,6 +41,12 @@ public class SyncUpdateFragment extends Fragment implements Receiver {
 					((SyncUpdateFragmentInterface) getActivity()).updateAfterSync();
 				}
 				break;
+			case SyncService.STATUS_PARTIAL_PROGRESS:
+				syncRunning = true;
+				if (getActivity() != null) {
+					((SyncUpdateFragmentInterface) getActivity()).updatePartialSync();
+				}
+				break;
 			case SyncService.STATUS_FINISHED_CLOSE:
 				syncRunning = false;
 				if (getActivity() != null) {
@@ -57,11 +64,11 @@ public class SyncUpdateFragment extends Fragment implements Receiver {
 				break;	
 			case SyncService.STATUS_ERROR:
 				syncRunning = false;
-				Log.e(TAG, "There was an error");
+				Log.e(this.getClass().getName(), "Sync completed with an error.");
 				break;		
 			default:
 				syncRunning = false;
-				Log.e(TAG, "Unrecognised response attempting to get reading data");
+				Log.e(this.getClass().getName(), "Sync completed with an unknown result.");
 				break;
 			}
 		}
@@ -75,6 +82,7 @@ public class SyncUpdateFragment extends Fragment implements Receiver {
 
 		public interface SyncUpdateFragmentInterface {
 			public void updateAfterSync();
+            public void updatePartialSync();
 			public void closeAfterUpdate();
 			public void setNothingMoreToUpdate();
 			public void updateSyncStatus(boolean syncRunning);

--- a/media/android/NewsBlur/src/com/newsblur/network/APIManager.java
+++ b/media/android/NewsBlur/src/com/newsblur/network/APIManager.java
@@ -451,10 +451,6 @@ public class APIManager {
 		}
 	}
 
-	public boolean getFolderFeedMapping() {
-		return getFolderFeedMapping(false);		
-	}
-	
 	public boolean getFolderFeedMapping(boolean doUpdateCounts) {
 		
 		final APIClient client = new APIClient(context);
@@ -462,9 +458,6 @@ public class APIManager {
 		final FeedFolderResponse feedUpdate = new FeedFolderResponse(response.responseString, gson); 
 		
 		if (response.responseCode == HttpStatus.SC_OK && !response.hasRedirected) {
-			if (feedUpdate.folders.size() == 0) {
-				return false;
-			}
 			
 			HashMap<String, Feed> existingFeeds = getExistingFeeds();
 			


### PR DESCRIPTION
Fix for issue #138  - actually do the two-step sync recommended by the API docs, first calling `/reader/feeds` with `update_counts` unset, then follow up with a call to `/reader/refresh_feeds`.
