### PR TITLE
Fix registration regression post #151 commit

### DIFF
--- a/media/android/NewsBlur/AndroidManifest.xml
+++ b/media/android/NewsBlur/AndroidManifest.xml
@@ -36,6 +36,7 @@
        	
 		<activity
             android:name=".activity.RegisterProgress"
+            android:noHistory="true"
             android:label="@string/get_started" />
 		
 		<activity

--- a/media/android/NewsBlur/src/com/newsblur/activity/RegisterProgress.java
+++ b/media/android/NewsBlur/src/com/newsblur/activity/RegisterProgress.java
@@ -8,11 +8,15 @@ import com.actionbarsherlock.app.SherlockFragmentActivity;
 import com.newsblur.R;
 import com.newsblur.fragment.RegisterProgressFragment;
 
+/**
+ * Show progress screen while registering request is being processed. This
+ * Activity doesn't extend NbFragmentActivity because it is one of the few
+ * Activities that will be shown while the user is still logged out.
+ */
 public class RegisterProgress extends SherlockFragmentActivity {
 
 	private FragmentManager fragmentManager;
 	private String currentTag = "fragment";
-	private String TAG = "RegisterProgressActivity";
 
 	@Override
 	protected void onCreate(Bundle bundle) {

--- a/media/android/NewsBlur/src/com/newsblur/fragment/RegisterProgressFragment.java
+++ b/media/android/NewsBlur/src/com/newsblur/fragment/RegisterProgressFragment.java
@@ -79,7 +79,6 @@ public class RegisterProgressFragment extends Fragment {
 			public void onClick(View arg0) {
 				Intent i = new Intent(getActivity(), AddSites.class);
 				startActivity(i);
-				getActivity().finish();
 			}
 		});
 
@@ -112,12 +111,10 @@ public class RegisterProgressFragment extends Fragment {
 					i.putExtra("username", username);
 					i.putExtra("password", password);
 					startActivity(i);
-					getActivity().finish();
 				}
 			} else {
 				Toast.makeText(getActivity(), extractErrorMessage(response), Toast.LENGTH_LONG).show();
 				startActivity(new Intent(getActivity(), Login.class));
-				getActivity().finish();
 			}
 		}
 


### PR DESCRIPTION
The RegistrationProgress activity needed to be handled via special case because it is one of the few activities that needs to run while the user is not logged in.  So having it follow the logic that was checked in with #151 around closing 'Activities from previous users if not logged in' caused a force close.
