### PR TITLE
Android: Force Logout if API Indicates Not Authed

### DIFF
--- a/media/android/NewsBlur/src/com/newsblur/fragment/LogoutDialogFragment.java
+++ b/media/android/NewsBlur/src/com/newsblur/fragment/LogoutDialogFragment.java
@@ -1,7 +1,5 @@
 package com.newsblur.fragment;
 
-import android.content.Intent;
-import android.content.SharedPreferences;
 import android.os.Bundle;
 import android.support.v4.app.DialogFragment;
 import android.view.LayoutInflater;
@@ -12,14 +10,9 @@ import android.widget.Button;
 import android.widget.TextView;
 
 import com.newsblur.R;
-import com.newsblur.activity.Login;
-import com.newsblur.database.BlurDatabase;
-import com.newsblur.util.PrefConstants;
 import com.newsblur.util.PrefsUtils;
 
 public class LogoutDialogFragment extends DialogFragment {
-
-	protected static final String TAG = "LogoutDialogFragment";
 
 	@Override
 	public void onCreate(Bundle savedInstanceState) {
@@ -37,16 +30,7 @@ public class LogoutDialogFragment extends DialogFragment {
 		Button okayButton = (Button) v.findViewById(R.id.dialog_button_okay);
 		okayButton.setOnClickListener(new OnClickListener() {
 			public void onClick(final View v) {
-				SharedPreferences preferences = getActivity().getSharedPreferences(PrefConstants.PREFERENCES, 0);
-				preferences.edit().clear().commit();
-				
-				BlurDatabase databaseHelper = new BlurDatabase(getActivity().getApplicationContext());
-				databaseHelper.dropAndRecreateTables();
-				
-				PrefsUtils.clearLogin(getActivity());
-				Intent i = new Intent(getActivity(), Login.class);
-				i.setFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
-				startActivity(i);
+                PrefsUtils.logout(getActivity());
 			}
 		});
 		

--- a/media/android/NewsBlur/src/com/newsblur/network/APIManager.java
+++ b/media/android/NewsBlur/src/com/newsblur/network/APIManager.java
@@ -468,6 +468,13 @@ public class APIManager {
 		final FeedFolderResponse feedUpdate = new FeedFolderResponse(response.responseString, gson); 
 		
 		if (response.responseCode == HttpStatus.SC_OK && !response.hasRedirected) {
+
+            // if the response says we aren't logged in, clear the DB and prompt for login. We test this
+            // here, since this the first sync call we make on launch if we believe we are cookied.
+            if (! feedUpdate.isAuthenticated) {
+                PrefsUtils.logout(context);
+                return false;
+            }
 			
 			HashMap<String, Feed> existingFeeds = getExistingFeeds();
 			

--- a/media/android/NewsBlur/src/com/newsblur/network/domain/FeedFolderResponse.java
+++ b/media/android/NewsBlur/src/com/newsblur/network/domain/FeedFolderResponse.java
@@ -33,13 +33,14 @@ public class FeedFolderResponse {
 	@SerializedName("social_feeds")
 	public SocialFeed[] socialFeeds;
 
-	public FeedFolderResponse() {
-	}
+	public boolean isAuthenticated;
 	
 	public FeedFolderResponse(String json, Gson gson) {
 
 		JsonParser parser = new JsonParser();
 		JsonObject asJsonObject = parser.parse(json).getAsJsonObject();
+
+        this.isAuthenticated = asJsonObject.get("authenticated").getAsBoolean();
 
 		JsonArray jsonFoldersArray = (JsonArray) asJsonObject.get("folders");
 		ArrayList<String> nestedFolderList = new ArrayList<String>();

--- a/media/android/NewsBlur/src/com/newsblur/util/PrefsUtils.java
+++ b/media/android/NewsBlur/src/com/newsblur/util/PrefsUtils.java
@@ -8,12 +8,15 @@ import java.net.URL;
 import java.net.URLConnection;
 
 import android.content.Context;
+import android.content.Intent;
 import android.content.SharedPreferences;
 import android.content.SharedPreferences.Editor;
 import android.graphics.Bitmap;
 import android.graphics.Bitmap.CompressFormat;
 import android.graphics.BitmapFactory;
 
+import com.newsblur.activity.Login;
+import com.newsblur.database.BlurDatabase;
 import com.newsblur.domain.UserDetails;
 
 public class PrefsUtils {
@@ -26,17 +29,24 @@ public class PrefsUtils {
 		edit.commit();
 	}
 
-	/**
-	 * Removes the current login session (i.e. logout)
-	 */
-	public static void clearLogin(final Context context) {
-		final SharedPreferences preferences = context.getSharedPreferences(PrefConstants.PREFERENCES, 0);
-		final Editor edit = preferences.edit();
-		edit.putString(PrefConstants.PREF_COOKIE, null);
-		edit.putString(PrefConstants.PREF_UNIQUE_LOGIN, null);
-		edit.commit();
-	}
-	
+    public static void logout(Context context) {
+
+        // TODO: stop or wait for any BG processes
+
+        // wipe the prefs store
+        context.getSharedPreferences(PrefConstants.PREFERENCES, 0).edit().clear().commit();
+        
+        // wipe the local DB
+        BlurDatabase databaseHelper = new BlurDatabase(context.getApplicationContext());
+        databaseHelper.dropAndRecreateTables();
+        
+        // prompt for a new login
+        Intent i = new Intent(context, Login.class);
+        i.setFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
+        context.startActivity(i);
+
+    }
+
 	/**
 	 * Retrieves the current unique login key. This key will be unique for each
 	 * login. If this login key doesn't match the login key you have then assume


### PR DESCRIPTION
Fix for issue #156 to simply clear session data and re-request login rather than show potentially confusing demo data.
