### PR TITLE
Android: Fix duplicate appearance of All Stories heading

### DIFF
--- a/media/android/NewsBlur/src/com/newsblur/database/DatabaseConstants.java
+++ b/media/android/NewsBlur/src/com/newsblur/database/DatabaseConstants.java
@@ -136,20 +136,6 @@ public class DatabaseConstants {
 		FOLDER_TABLE + "." + FOLDER_ID, FOLDER_TABLE + "." + FOLDER_NAME, " SUM(" + FEED_POSITIVE_COUNT + ") AS " + SUM_POS, " SUM(" + FEED_NEUTRAL_COUNT + ") AS " + SUM_NEUT, " SUM(" + FEED_NEGATIVE_COUNT + ") AS " + SUM_NEG
 	};
 
-    // this union clause lets folder queries also select the "root" folder that should appear whether or not
-    // it has unread stories. Note that this goes *before* the normal ALL_FOLDERS select statement. The zero-valued
-    // pseudo-columns are safe because said columns are ignored for the root folder. This is necessary because the
-    // joins used in order to fetch folders by unread count are all inner joins, and sqlite does not support
-    // full outer joins.
-    public static final String FOLDER_UNION_ROOT = "SELECT " +
-            FOLDER_ID + ", " +
-            FOLDER_NAME +
-            ", 0 AS " + SUM_POS +
-            ", 0 AS " + SUM_NEUT +
-            ", 0 AS " + SUM_NEG +
-            " FROM " + FOLDER_TABLE +
-            " WHERE " + FOLDER_NAME + "='" + AppConstants.ROOT_FOLDER + "' UNION ";
-
     private static final String FOLDER_INTELLIGENCE_ALL = " HAVING SUM(" + DatabaseConstants.FEED_NEGATIVE_COUNT + " + " + DatabaseConstants.FEED_NEUTRAL_COUNT + " + " + DatabaseConstants.FEED_POSITIVE_COUNT + ") >= 0";
     private static final String FOLDER_INTELLIGENCE_SOME = " HAVING SUM(" + DatabaseConstants.FEED_NEUTRAL_COUNT + " + " + DatabaseConstants.FEED_POSITIVE_COUNT + ") > 0";
     private static final String FOLDER_INTELLIGENCE_BEST = " HAVING SUM(" + DatabaseConstants.FEED_POSITIVE_COUNT + ") > 0";


### PR DESCRIPTION
The saga of the scary sqlite queries continues!  This should finally get the All Stories heading to always appear exactly once for any of the following test cases:
1. Users with no root-level feeds
2. Users with root-level feeds that have no unread stories
3. Users with root-level feeds that do have unread stories

Tested on a real Nexus One, a real Nexus 4, a simulated Nexus 4, and a simulated Nexus 7.
