### PR TITLE
Typo fix and some work making things a little more generic

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -429,7 +429,7 @@ def setup_repo_local_settings():
 def copy_local_settings():
     with cd(env.NEWSBLUR_PATH):
         put('local_settings.py.server', 'local_settings.py')
-
+cp
 def setup_local_files():
     put("config/toprc", "./.toprc")
     put("config/zshrc", "./.zshrc")
@@ -1041,19 +1041,19 @@ def setup_do(name, size=2):
 
 def add_user_to_do():
     env.user = "root"
-    doUser = "sclay"
+    repo_user = "sclay"
     with settings(warn_only=True):
-        run('useradd -m %s' % (doUser))
-        setup_sudoers("%s" % (doUser))
-    run('mkdir -p ~%s/.ssh && chmod 700 ~%s/.ssh' % (doUser, doUser))
-    run('rm -fr ~%s/.ssh/id_dsa*' % (doUser))
-    run('ssh-keygen -t dsa -f ~%s/.ssh/id_dsa -N ""' % (doUser, doUser))
-    run('touch ~%s/.ssh/authorized_keys' % (doUser, doUser))
+        run('useradd -m %s' % (repo_user))
+        setup_sudoers("%s" % (repo_user))
+    run('mkdir -p ~%s/.ssh && chmod 700 ~%s/.ssh' % (repo_user, repo_user))
+    run('rm -fr ~%s/.ssh/id_dsa*' % (repo_user))
+    run('ssh-keygen -t dsa -f ~%s/.ssh/id_dsa -N ""' % (repo_user, repo_user))
+    run('touch ~%s/.ssh/authorized_keys' % (repo_user, repo_user))
     put("~/.ssh/id_dsa.pub", "authorized_keys")
-    run('echo `cat authorized_keys` >> ~%s/.ssh/authorized_keys' % (doUser))
+    run('echo `cat authorized_keys` >> ~%s/.ssh/authorized_keys' % (repo_user))
     run('rm authorized_keys')
-    run('chown %s.%s -R ~%s/.ssh' % (doUser, doUser, doUser))
-    env.user = "%s"
+    run('chown %s.%s -R ~%s/.ssh' % (repo_user, repo_user, repo_user))
+    env.user = repo_user
 
 # ===============
 # = Setup - EC2 =

--- a/settings.py
+++ b/settings.py
@@ -79,7 +79,7 @@ ALLOWED_HOSTS         = ['*']
 
 PRODUCTION  = NEWSBLUR_DIR.find('/home/conesus/newsblur') == 0
 STAGING     = NEWSBLUR_DIR.find('/home/conesus/staging') == 0
-DEVELOPMENT = (NEWSBLUR_DIR.find('/Users/') == 0) or (NEWSBLUR_DIR.find('/home/') == 0)  # the path to ~/ is only "Users" on a mac. it's `home` on linux
+DEVELOPMENT = (NEWSBLUR_DIR.find('/Users/') == 0)
 
 # ===========================
 # = Django-specific Modules =


### PR DESCRIPTION
Here is the typo fix for fabfile.py.

I also broke the stuff that switches you over to zsh out into a separate fab command (and stuck it in setup_all). That should make it a little more obvious that setup_all will change your shell, as well as make it easier to disable.

My text editor (sublime text) automatically trims trailing spaces upon every save, so that happened too.

I haven't actually managed to get a complete install working yet, so I can't say I didn't introduce any bugs. It certainly loads with `fab`, but there are a lot of assumptions about pre-existing folder structure that must be met before the install will work properly, and I'm still puzzling them out.
