### PR TITLE
Android: Remove Cosmetic sleep() on Login

### DIFF
--- a/media/android/NewsBlur/src/com/newsblur/fragment/LoginProgressFragment.java
+++ b/media/android/NewsBlur/src/com/newsblur/fragment/LoginProgressFragment.java
@@ -80,12 +80,6 @@ public class LoginProgressFragment extends Fragment {
 		protected LoginResponse doInBackground(String... params) {
 			LoginResponse response = apiManager.login(username, password);
 			apiManager.updateUserProfile();
-			try {
-				// TODO: get rid of this and use proper UI transactions
-				Thread.sleep(500);
-			} catch (InterruptedException e) {
-				Log.e(this.getClass().getName(), "Error sleeping during login.");
-			}
 			return response;
 		}
 


### PR DESCRIPTION
Having done some research around the root causes of the issue seen in #220 and what might make getActivity() return null, this block of code has become suspect.

This delay after login has a purely cosmetic intent but might be causing timing effects that violate the activity lifecycle by hard blocking the UI thread.  Going ahead and removing it since it, at best, has a smell to it and may very well be the root cause of the crashes.
