### PR TITLE
Android: Auto-Sync Feeds/Folders

### DIFF
--- a/media/android/NewsBlur/src/com/newsblur/activity/Main.java
+++ b/media/android/NewsBlur/src/com/newsblur/activity/Main.java
@@ -54,11 +54,20 @@ public class Main extends NbFragmentActivity implements StateChangedListener, Sy
 		}
 	}
 
+    @Override
+    protected void onResume() {
+        super.onResume();
+        if (PrefsUtils.isTimeToAutoSync(this)) {
+            triggerRefresh();
+        }
+    }
+
     /**
      * Triggers an initial two-phase sync, so the UI can display quickly using /reader/feeds and
      * then call /reader/refresh_feeds to get updated counts.
      */
 	private void triggerFirstSync() {
+        PrefsUtils.updateLastSyncTime(this);
 		setSupportProgressBarIndeterminateVisibility(true);
 		if (menu != null) {
 			menu.findItem(R.id.menu_refresh).setEnabled(false);
@@ -74,6 +83,7 @@ public class Main extends NbFragmentActivity implements StateChangedListener, Sy
      * Triggers a full, manually requested refresh of feed/folder data and counts.
      */
     private void triggerRefresh() {
+        PrefsUtils.updateLastSyncTime(this);
 		setSupportProgressBarIndeterminateVisibility(true);
 		if (menu != null) {
 			menu.findItem(R.id.menu_refresh).setEnabled(false);

--- a/media/android/NewsBlur/src/com/newsblur/util/AppConstants.java
+++ b/media/android/NewsBlur/src/com/newsblur/util/AppConstants.java
@@ -22,4 +22,10 @@ public class AppConstants {
 
     // the max number of mark-as-read ops to batch up before flushing to the server
     public static final int MAX_MARK_READ_BATCH = 5;
+
+    // a pref for the time we completed the last full sync of the feed/fodler list
+    public static final String LAST_SYNC_TIME = "LAST_SYNC_TIME";
+
+    // how long to wait before auto-syncing the feed/folder list
+    public static final long AUTO_SYNC_TIME_MILLIS = 10L * 60L * 1000L;
 }

--- a/media/android/NewsBlur/src/com/newsblur/util/PrefsUtils.java
+++ b/media/android/NewsBlur/src/com/newsblur/util/PrefsUtils.java
@@ -6,6 +6,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
 import java.net.URLConnection;
+import java.util.Date;
 
 import android.content.Context;
 import android.content.Intent;
@@ -159,5 +160,23 @@ public class PrefsUtils {
 		}
 	}
 
+    /**
+     * Check to see if it has been sufficiently long since the last sync of the feed/folder
+     * data to justify automatically syncing again.
+     */
+    public static boolean isTimeToAutoSync(Context context) {
+        SharedPreferences prefs = context.getSharedPreferences(PrefConstants.PREFERENCES, 0);
+        long lastTime = prefs.getLong(AppConstants.LAST_SYNC_TIME, 1L);
+        return ( (lastTime + AppConstants.AUTO_SYNC_TIME_MILLIS) < (new Date()).getTime() );
+    }
+
+    /**
+     * Make note that a sync of the feed/folder list has been completed, so we can track
+     * how long it has been until another is needed.
+     */
+    public static void updateLastSyncTime(Context context) {
+        SharedPreferences prefs = context.getSharedPreferences(PrefConstants.PREFERENCES, 0);
+        prefs.edit().putLong(AppConstants.LAST_SYNC_TIME, (new Date()).getTime()).commit();
+    }
 
 }


### PR DESCRIPTION
Fixing issue #237 - the android app never actually had the expected behaviour of automatically syncing folders/feeds every 10 minutes, but was rather relying on app kills/restarts or manual refreshes.
