### PR TITLE
Fixed gravatar hash to lowercase the email address.

### DIFF
--- a/apps/social/models.py
+++ b/apps/social/models.py
@@ -2014,7 +2014,7 @@ class MSocialServices(mongo.Document):
             },
             'gravatar': {
                 'gravatar_picture_url': "https://www.gravatar.com/avatar/" + \
-                                        hashlib.md5(user.email).hexdigest()
+                                        hashlib.md5(user.email.lower()).hexdigest()
             },
             'upload': {
                 'upload_picture_url': self.upload_picture_url


### PR DESCRIPTION
http://en.gravatar.com/site/implement/images/python/

I don't actually know how to run this locally, so I assume `user.email` always exists and is a string.
