### PR TITLE
Android: Fix all_stories String Regression

### DIFF
--- a/media/android/NewsBlur/res/layout/row_all_stories.xml
+++ b/media/android/NewsBlur/res/layout/row_all_stories.xml
@@ -23,7 +23,7 @@
         android:layout_marginLeft="50dp"
         android:paddingBottom="15dp"
         android:paddingTop="15dp"
-        android:text="@string/all_stories"
+        android:text="@string/all_stories_row_title"
         android:textColor="@color/folder_text"
         android:textSize="16dp"
         android:textStyle="bold" />

--- a/media/android/NewsBlur/res/values/strings.xml
+++ b/media/android/NewsBlur/res/values/strings.xml
@@ -33,7 +33,7 @@
 	<string name="reading_shared_count">%s SHARES</string>
 	<string name="reading_comment_count">%s COMMENTS</string>
 	
-	<string name="all_stories">ALL STORIES</string>
+	<string name="all_stories_row_title">ALL STORIES</string>
 	<string name="all_shared_stories">ALL SHARED STORIES</string>
 	
 	<string name="now">now</string>

--- a/media/android/NewsBlur/src/com/newsblur/activity/AllStoriesReading.java
+++ b/media/android/NewsBlur/src/com/newsblur/activity/AllStoriesReading.java
@@ -33,7 +33,7 @@ public class AllStoriesReading extends Reading {
 		
 		StoryOrder storyOrder = PrefsUtils.getStoryOrderForFolder(this, PrefConstants.ALL_STORIES_FOLDER_NAME);
 		stories = contentResolver.query(FeedProvider.ALL_STORIES_URI, null, DatabaseConstants.getStorySelectionFromState(currentState), null, DatabaseConstants.getStorySortOrder(storyOrder));
-		setTitle(getResources().getString(R.string.all_stories));
+		setTitle(getResources().getString(R.string.all_stories_row_title));
 		readingAdapter = new MixedFeedsReadingAdapter(getSupportFragmentManager(), getContentResolver(), stories);
 
 		setupPager();


### PR DESCRIPTION
Super quick fix for a very visible regression picked up in #266.  Turns out the compiler doesn't barf if a value in R.values.strings is duplicated. :(  Fixed things up so the ALL STORIES row is once more capitalized as intended.
