### PR TITLE
API: Starred story date parsing (starred_stories)

### DIFF
--- a/apps/reader/views.py
+++ b/apps/reader/views.py
@@ -590,9 +590,9 @@ def load_single_feed(request, feed_id):
                 story['read_status'] = 1 if story['story_hash'] not in unread_story_hashes else 0
             if story['story_hash'] in starred_stories:
                 story['starred'] = True
-                starred_date = localtime_for_timezone(starred_stories[story['story_hash']],
-                                                      user.profile.timezone)
-                story['starred_date'] = format_story_link_date__long(starred_date, now)
+                starred_date = localtime_for_timezone(starred_stories[story['story_hash']], user.profile.timezone)
+            	story['short_parsed_starred_date'] = format_story_link_date__short(starred_date, now)
+        		story['long_parsed_starred_date'] = format_story_link_date__long(starred_date, now)
             if story['story_hash'] in shared_stories:
                 story['shared'] = True
                 shared_date = localtime_for_timezone(shared_stories[story['story_hash']]['shared_date'],
@@ -743,7 +743,8 @@ def load_starred_stories(request):
         story['short_parsed_date'] = format_story_link_date__short(story_date, now)
         story['long_parsed_date']  = format_story_link_date__long(story_date, now)
         starred_date               = localtime_for_timezone(story['starred_date'], user.profile.timezone)
-        story['starred_date']      = format_story_link_date__long(starred_date, now)
+        story['short_parsed_starred_date'] = format_story_link_date__short(starred_date, now)
+        story['long_parsed_starred_date'] = format_story_link_date__long(starred_date, now)
         story['read_status']       = 1
         story['starred']           = True
         story['intelligence']      = {
@@ -842,9 +843,9 @@ def load_river_stories__redis(request):
         story['long_parsed_date']  = format_story_link_date__long(story_date, now)
         if story['story_hash'] in starred_stories:
             story['starred'] = True
-            starred_date = localtime_for_timezone(starred_stories[story['story_hash']],
-                                                  user.profile.timezone)
-            story['starred_date'] = format_story_link_date__long(starred_date, now)
+            starred_date = localtime_for_timezone(starred_stories[story['story_hash']], user.profile.timezone)
+        	story['short_parsed_starred_date'] = format_story_link_date__short(starred_date, now)
+        	story['long_parsed_starred_date'] = format_story_link_date__long(starred_date, now)
         story['intelligence'] = {
             'feed':   apply_classifier_feeds(classifier_feeds, story['story_feed_id']),
             'author': apply_classifier_authors(classifier_authors, story),


### PR DESCRIPTION
Update #1:
I added short_parsed_starred_date and long_parsed_starred_date,
Hope I did everything right never worked with Pyhton and Github before.

Original request:
I’m working on a new (C#) Windows Phone 8 NewsBlur application but I’m having a hard time parsing the starred date time because it contains Today/Yesterday and sometimes it does contain the year and sometimes it doesn't, the default (C#) DateTime.Parse doesn't recognize those words and will lead to a error.

Can you please add a separate long_parsed_starred_date to the starred_stories API
 like the story_date and long_parsed_date in the river_stories API?

Example:
 "starred_date": "2013-05-29 10:30:00",
 "long_parsed_starred_date": "Wednesday, May 29th, 2013 6:30am",

This will help me a lot with finishing my application in the best possible way.
 Thanks in advance and for been so open with your development progress.

Greets,
Arnold Vink
