### PR TITLE
Android: Confirmation when marking folder or all stories read

### DIFF
--- a/media/android/NewsBlur/res/values/strings.xml
+++ b/media/android/NewsBlur/res/values/strings.xml
@@ -165,4 +165,9 @@
         <item>UNREAD</item>
     </string-array>
     <string name="default_read_filter_value">ALL</string>
+    
+    <string-array name="mark_all_read_options">
+        <item>Mark entire folder read</item>
+        <item>Cancel</item>
+    </string-array>
 </resources>

--- a/media/android/NewsBlur/src/com/newsblur/activity/AllStoriesItemsList.java
+++ b/media/android/NewsBlur/src/com/newsblur/activity/AllStoriesItemsList.java
@@ -1,11 +1,8 @@
 package com.newsblur.activity;
 
-import java.util.ArrayList;
-
 import android.content.ContentResolver;
 import android.content.ContentValues;
 import android.content.Intent;
-import android.database.Cursor;
 import android.os.AsyncTask;
 import android.os.Bundle;
 import android.support.v4.app.FragmentTransaction;
@@ -18,7 +15,9 @@ import com.newsblur.database.DatabaseConstants;
 import com.newsblur.database.FeedProvider;
 import com.newsblur.fragment.AllStoriesItemListFragment;
 import com.newsblur.fragment.FeedItemListFragment;
+import com.newsblur.fragment.MarkAllReadDialogFragment;
 import com.newsblur.fragment.SyncUpdateFragment;
+import com.newsblur.fragment.MarkAllReadDialogFragment.MarkAllReadDialogListener;
 import com.newsblur.network.APIManager;
 import com.newsblur.service.SyncService;
 import com.newsblur.util.PrefConstants;
@@ -26,7 +25,7 @@ import com.newsblur.util.PrefsUtils;
 import com.newsblur.util.ReadFilter;
 import com.newsblur.util.StoryOrder;
 
-public class AllStoriesItemsList extends ItemsList {
+public class AllStoriesItemsList extends ItemsList implements MarkAllReadDialogListener {
 
 	private APIManager apiManager;
 	private ContentResolver resolver;
@@ -83,29 +82,8 @@ public class AllStoriesItemsList extends ItemsList {
 
 	@Override
 	public void markItemListAsRead() {
-		new AsyncTask<Void, Void, Boolean>() {
-			@Override
-			protected Boolean doInBackground(Void... arg) {
-				return apiManager.markAllAsRead();
-			}
-			
-			@Override
-			protected void onPostExecute(Boolean result) {
-				if (result) {
-					// mark all feed IDs as read
-					ContentValues values = new ContentValues();
-					values.put(DatabaseConstants.FEED_NEGATIVE_COUNT, 0);
-					values.put(DatabaseConstants.FEED_NEUTRAL_COUNT, 0);
-					values.put(DatabaseConstants.FEED_POSITIVE_COUNT, 0);
-                    resolver.update(FeedProvider.FEEDS_URI, values, null, null);
-					setResult(RESULT_OK); 
-					Toast.makeText(AllStoriesItemsList.this, R.string.toast_marked_all_stories_as_read, Toast.LENGTH_SHORT).show();
-					finish();
-				} else {
-					Toast.makeText(AllStoriesItemsList.this, R.string.toast_error_marking_feed_as_read, Toast.LENGTH_SHORT).show();
-				}
-			};
-		}.execute();
+	    MarkAllReadDialogFragment dialog = MarkAllReadDialogFragment.newInstance(getResources().getString(R.string.all_stories));
+        dialog.show(fragmentManager, "dialog");
 	}
 
 	@Override
@@ -138,5 +116,37 @@ public class AllStoriesItemsList extends ItemsList {
     @Override
     protected ReadFilter getReadFilter() {
         return PrefsUtils.getReadFilterForFolder(this, PrefConstants.ALL_STORIES_FOLDER_NAME);
+    }
+
+    @Override
+    public void onMarkAllRead() {
+        new AsyncTask<Void, Void, Boolean>() {
+            @Override
+            protected Boolean doInBackground(Void... arg) {
+                return apiManager.markAllAsRead();
+            }
+            
+            @Override
+            protected void onPostExecute(Boolean result) {
+                if (result) {
+                    // mark all feed IDs as read
+                    ContentValues values = new ContentValues();
+                    values.put(DatabaseConstants.FEED_NEGATIVE_COUNT, 0);
+                    values.put(DatabaseConstants.FEED_NEUTRAL_COUNT, 0);
+                    values.put(DatabaseConstants.FEED_POSITIVE_COUNT, 0);
+                    resolver.update(FeedProvider.FEEDS_URI, values, null, null);
+                    setResult(RESULT_OK); 
+                    Toast.makeText(AllStoriesItemsList.this, R.string.toast_marked_all_stories_as_read, Toast.LENGTH_SHORT).show();
+                    finish();
+                } else {
+                    Toast.makeText(AllStoriesItemsList.this, R.string.toast_error_marking_feed_as_read, Toast.LENGTH_SHORT).show();
+                }
+            };
+        }.execute();
+    }
+
+    @Override
+    public void onCancel() {
+        // do nothing
     }
 }

--- a/media/android/NewsBlur/src/com/newsblur/activity/FolderItemsList.java
+++ b/media/android/NewsBlur/src/com/newsblur/activity/FolderItemsList.java
@@ -16,6 +16,8 @@ import com.newsblur.database.DatabaseConstants;
 import com.newsblur.database.FeedProvider;
 import com.newsblur.fragment.FeedItemListFragment;
 import com.newsblur.fragment.FolderItemListFragment;
+import com.newsblur.fragment.MarkAllReadDialogFragment;
+import com.newsblur.fragment.MarkAllReadDialogFragment.MarkAllReadDialogListener;
 import com.newsblur.fragment.SyncUpdateFragment;
 import com.newsblur.network.APIManager;
 import com.newsblur.network.MarkFolderAsReadTask;
@@ -24,7 +26,7 @@ import com.newsblur.util.PrefsUtils;
 import com.newsblur.util.ReadFilter;
 import com.newsblur.util.StoryOrder;
 
-public class FolderItemsList extends ItemsList {
+public class FolderItemsList extends ItemsList implements MarkAllReadDialogListener {
 
 	public static final String EXTRA_FOLDER_NAME = "folderName";
 	private String folderName;
@@ -99,18 +101,8 @@ public class FolderItemsList extends ItemsList {
 
 	@Override
 	public void markItemListAsRead() {
-		new MarkFolderAsReadTask(apiManager, getContentResolver()) {
-			@Override
-			protected void onPostExecute(Boolean result) {
-				if (result) {
-					setResult(RESULT_OK);
-					Toast.makeText(FolderItemsList.this, R.string.toast_marked_folder_as_read, Toast.LENGTH_SHORT).show();
-					finish();
-				} else {
-					Toast.makeText(FolderItemsList.this, R.string.toast_error_marking_feed_as_read, Toast.LENGTH_SHORT).show();
-				}
-			}
-		}.execute(folderName);
+	    MarkAllReadDialogFragment dialog = MarkAllReadDialogFragment.newInstance(folderName);
+	    dialog.show(fragmentManager, "dialog");
 	}
 
 	@Override
@@ -135,5 +127,26 @@ public class FolderItemsList extends ItemsList {
     @Override
     protected ReadFilter getReadFilter() {
         return PrefsUtils.getReadFilterForFolder(this, folderName);
+    }
+
+    @Override
+    public void onMarkAllRead() {
+        new MarkFolderAsReadTask(apiManager, getContentResolver()) {
+            @Override
+            protected void onPostExecute(Boolean result) {
+                if (result) {
+                    setResult(RESULT_OK);
+                    Toast.makeText(FolderItemsList.this, R.string.toast_marked_folder_as_read, Toast.LENGTH_SHORT).show();
+                    finish();
+                } else {
+                    Toast.makeText(FolderItemsList.this, R.string.toast_error_marking_feed_as_read, Toast.LENGTH_SHORT).show();
+                }
+            }
+        }.execute(folderName);
+    }
+
+    @Override
+    public void onCancel() {
+        // do nothing
     }
 }

--- a/media/android/NewsBlur/src/com/newsblur/fragment/MarkAllReadDialogFragment.java
+++ b/media/android/NewsBlur/src/com/newsblur/fragment/MarkAllReadDialogFragment.java
@@ -1,0 +1,52 @@
+package com.newsblur.fragment;
+
+import com.newsblur.R;
+
+import android.app.Activity;
+import android.app.AlertDialog;
+import android.app.Dialog;
+import android.content.DialogInterface;
+import android.os.Bundle;
+import android.support.v4.app.DialogFragment;
+
+public class MarkAllReadDialogFragment extends DialogFragment {
+    private static final String FOLDER_NAME = "folder_name";
+    
+    public interface MarkAllReadDialogListener {
+        public void onMarkAllRead();
+        public void onCancel();
+    }
+    
+    private MarkAllReadDialogListener listener;
+    
+    public static MarkAllReadDialogFragment newInstance(String folderName) {
+        MarkAllReadDialogFragment fragment = new MarkAllReadDialogFragment();
+        Bundle args = new Bundle();
+        args.putString(FOLDER_NAME, folderName);
+        fragment.setArguments(args);
+        return fragment;
+    }
+    
+    @Override
+    public void onAttach(Activity activity) {
+        super.onAttach(activity);
+        listener = (MarkAllReadDialogListener)activity;
+    }
+
+    @Override
+    public Dialog onCreateDialog(Bundle savedInstanceState) {
+        AlertDialog.Builder builder = new AlertDialog.Builder(getActivity());
+        builder.setTitle(getArguments().getString(FOLDER_NAME))
+               .setItems(R.array.mark_all_read_options, new DialogInterface.OnClickListener() {
+                   public void onClick(DialogInterface dialog, int which) {
+                       if (which == 0) {
+                           listener.onMarkAllRead();
+                       } else {
+                           listener.onCancel();
+                       }
+
+               }
+        });
+        return builder.create();
+    }
+}


### PR DESCRIPTION
First pull request for fixing #295.

This adds a confirmation with "Mark entire folder read" and "Cancel" options when marking a folder or all stories as read.

Tested on my Nexus 4.
