### PR TITLE
Define additional keybindings (S-n and S-p) for selecting the next or previous site.

### DIFF
--- a/media/js/newsblur/reader/reader.js
+++ b/media/js/newsblur/reader/reader.js
@@ -5399,6 +5399,14 @@
             $document.bind('keydown', 'shift+k', function(e) {
                 e.preventDefault();
                 self.show_next_feed(-1);
+            });
+            $document.bind('keydown', 'shift+n', function(e) {
+                e.preventDefault();
+                self.show_next_feed(1);
+            });
+            $document.bind('keydown', 'shift+p', function(e) {
+                e.preventDefault();
+                self.show_next_feed(-1);
             });                       
             $document.bind('keydown', 'shift+down', function(e) {
                 e.preventDefault();

--- a/media/js/newsblur/reader/reader_keyboard.js
+++ b/media/js/newsblur/reader/reader_keyboard.js
@@ -68,6 +68,7 @@ _.extend(NEWSBLUR.ReaderKeyboard.prototype, {
                     $.make('span', '+'),
                     'j'
                 ])
+                // TODO: Mention "shift + n" here? It will be too wide.
               ]),
               $.make('div', { className: 'NB-keyboard-shortcut NB-last' }, [
                 $.make('div', { className: 'NB-keyboard-shortcut-explanation' }, 'Prev. site'),
@@ -81,6 +82,7 @@ _.extend(NEWSBLUR.ReaderKeyboard.prototype, {
                     $.make('span', '+'),
                     'k'
                 ])
+                // TODO: Mention "shift + p" here? It will be too wide.
               ])
             ]),
             $.make('div', { className: 'NB-keyboard-group' }, [              


### PR DESCRIPTION
In support of [a support request](https://getsatisfaction.com/newsblur/topics/keyboard_shortcuts-rkca2)  made two months ago, this patch proposes adding two key bindings:
- _Shift-N_ → Next Site
- _Shift-P_ → Previous Site

These are already bound to Shift-J/Shift-↓ and Shift-K/Shift-↑, respectively, so adding a third is likely controversial. The keyboard shortcut help screen already has double-wide entries for these commands; I was reluctant to add a third there, fearing that the layout couldn't handle rows that wide.

Many of the keyboard shortcuts in NewsBlur mimic those from Google Reader, as is the custom in the current flourish of RSS Web-based readers. While Google Reader _accepts_ Shift-J and Shift-K to move among subscriptions, note that its _advertised_ bindings for those commands are Shift-N and Shift-P, as I've proposed adding here.
