### PR TITLE
Fix default feed pane size to fit buttons with labels

### DIFF
--- a/apps/profile/models.py
+++ b/apps/profile/models.py
@@ -39,7 +39,7 @@ class Profile(models.Model):
     preferences       = models.TextField(default="{}")
     view_settings     = models.TextField(default="{}")
     collapsed_folders = models.TextField(default="[]")
-    feed_pane_size    = models.IntegerField(default=240)
+    feed_pane_size    = models.IntegerField(default=242)
     tutorial_finished = models.BooleanField(default=False)
     hide_getting_started = models.NullBooleanField(default=False, null=True, blank=True)
     has_setup_feeds   = models.NullBooleanField(default=False, null=True, blank=True)

--- a/config/fixtures/bootstrap.json
+++ b/config/fixtures/bootstrap.json
@@ -12,7 +12,7 @@
         "model": "profile.profile",
         "fields": {
             "secret_token": "4a700381ea08",
-            "feed_pane_size": 240,
+            "feed_pane_size": 242,
             "last_seen_ip": null,
             "view_settings": "{}",
             "is_premium": false,

--- a/media/js/newsblur/reader/reader.js
+++ b/media/js/newsblur/reader/reader.js
@@ -260,7 +260,7 @@
                 togglerLength_open:     0
             }); 
             
-            if (this.model.preference('feed_pane_size') < 240) {
+            if (this.model.preference('feed_pane_size') < 242) {
                 this.layout.outerLayout.resizeAll();
             }
             

--- a/templates/base.html
+++ b/templates/base.html
@@ -34,7 +34,7 @@
     NEWSBLUR.Preferences = {
       'unread_view'             : 0,
       'lock_mouse_indicator'    : 100,
-      'feed_pane_size'          : {% firstof user_profile.feed_pane_size 240 %},
+      'feed_pane_size'          : {% firstof user_profile.feed_pane_size 242 %},
       'hide_getting_started'    : {{ user_profile.hide_getting_started|yesno:"true,false" }},
       'has_setup_feeds'         : {{ user_profile.has_setup_feeds|yesno:"true,false" }},
       'has_found_friends'       : {{ user_profile.has_found_friends|yesno:"true,false" }},

--- a/templates/reader/dashboard.xhtml
+++ b/templates/reader/dashboard.xhtml
@@ -31,7 +31,7 @@
 <h1 class="NB-splash-heading">NewsBlur</h1>
 <h2 class="NB-splash-heading">- The best stories from your friends and favorite blogs, all in one place.</h2>
 
-<div id="NB-splash" style="left: {% firstof user_profile.feed_pane_size 240 %}px">
+<div id="NB-splash" style="left: {% firstof user_profile.feed_pane_size 242 %}px">
     <div class="NB-splash-modules">
     <div class="NB-modules-center">
     


### PR DESCRIPTION
Second attempt!

I'm not sure where the labels are hidden when the feed pane size gets decreased. If you point me in the right direction, I'm happy to have a look at fixing that, too (at least none of these diffs seem like they will change that).
