### PR TITLE
Android: API Retry Logic

### DIFF
--- a/clients/android/NewsBlur/src/com/newsblur/util/AppConstants.java
+++ b/clients/android/NewsBlur/src/com/newsblur/util/AppConstants.java
@@ -28,4 +28,10 @@ public class AppConstants {
 
     // how long to wait before auto-syncing the feed/folder list
     public static final long AUTO_SYNC_TIME_MILLIS = 10L * 60L * 1000L;
+
+    // how many total attemtps to make at a single API call
+    public static final int MAX_API_TRIES = 3;
+
+    // the base amount for how long to sleep during exponential API failure backoff
+    public static final long API_BACKOFF_BASE_MILLIS = 500L;
 }


### PR DESCRIPTION
With the refactored API manager, we can now implement #247 properly.  This only triggers retries on very low-level failures such as connects failures, timeouts, etc.  I also implemented exponential backoff logic so the NB servers won't get hammered in the event of duress.  If the server returns a response with an error or throttle message in it (so long as it is a 200), calls will immediately stop.  The retry count and interval were chosen after looking at some logs from failed calls and should be well suited to the top causes of failure - pool exhaustion (very fast) and radio mode switching (1-2 seconds).
