### PR TITLE
Allow only POST when marking stories as read/unread

### DIFF
--- a/api/newsblur.py
+++ b/api/newsblur.py
@@ -183,7 +183,7 @@ class API:
             data.append( ("feeds", feed) )
         return data
     
-    @request('reader/mark_story_as_read')
+    @request('reader/mark_story_as_read', method='post')
     def mark_story_as_read(self, feed_id, story_ids):
         '''
          Mark stories as read.
@@ -197,7 +197,7 @@ class API:
             data.append( ("story_id", story_id) )
         return data
 
-    @request('reader/mark_story_as_starred')
+    @request('reader/mark_story_as_starred', method='post')
     def mark_story_as_starred(self, feed_id, story_id):
         '''
         Mark a story as starred (saved).


### PR DESCRIPTION
I'm not entirely sure this works (so please review it), but I'm hoping this would cause the "Invalid method. Use POST. You used GET" to return from the API when using GET.
I think it would be best to support only POST here and let the user know of it.
