### PR TITLE
FIX: Crash on "mark as unread"

### DIFF
--- a/clients/ios/Classes/NewsBlurAppDelegate.m
+++ b/clients/ios/Classes/NewsBlurAppDelegate.m
@@ -1557,7 +1557,7 @@
         [self.recentlyReadFeeds removeObject:[newStory objectForKey:@"story_feed_id"]];
 //    }
     
-    NSDictionary *unreadCounts = [self.dictUnreadCounts objectForKey:[feed objectForKey:feedIdStr]];
+    NSDictionary *unreadCounts = [self.dictUnreadCounts objectForKey:feedIdStr];
     NSMutableDictionary *newUnreadCounts = [unreadCounts mutableCopy];
     int score = [NewsBlurAppDelegate computeStoryScore:[story objectForKey:@"intelligence"]];
     if (score > 0) {


### PR DESCRIPTION
Fixes a crash that occurs if you click on "mark as unread" while looking at a news.
