### PR TITLE
Fix button cutoff CSS bug

### DIFF
--- a/media/css/reader.css
+++ b/media/css/reader.css
@@ -3511,7 +3511,7 @@ background: transparent;
     overflow: hidden;
 }
 .NB-feed-taskbar .NB-task-button {
-    padding: 7px 8px;
+    padding: 7px;
     cursor: pointer;
     opacity: .9;
 }


### PR DESCRIPTION
Before:
![newsblur before](http://imgh.us/newsblur.png)

After:
![newsblur after](http://imgh.us/newsblur_2.png)
