### PR TITLE
iOS: Use checkmark HUD instead of alert view when posting to read later service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,6 @@ media/android/NewsBlur/local.properties
 media/android/NewsBlurTest/local.properties
 originals
 media/safari/NewsBlur.safariextz
+
+# IDE files
+.idea

--- a/clients/ios/Classes/StoryDetailViewController.m
+++ b/clients/ios/Classes/StoryDetailViewController.m
@@ -1359,6 +1359,8 @@ shouldStartLoadWithRequest:(NSURLRequest *)request
         self.storyHUD.labelText = @"No longer saved";
     } else if ([messageType isEqualToString:@"unread"]) {
         self.storyHUD.labelText = @"Unread";
+    } else if ([messageType isEqualToString:@"added"]) {
+        self.storyHUD.labelText = @"Added";
     }
     [self.storyHUD hide:YES afterDelay:1];
 }

--- a/clients/ios/Classes/StoryPageControl.h
+++ b/clients/ios/Classes/StoryPageControl.h
@@ -113,6 +113,9 @@
 - (void)showShareHUD:(NSString *)msg;
 
 - (IBAction)showOriginalSubview:(id)sender;
+
+- (void)flashCheckmarkHud:(NSString *)messageType;
+
 - (IBAction)doNextUnreadStory;
 - (IBAction)doPreviousStory;
 - (IBAction)tapProgressBar:(id)sender;

--- a/clients/ios/Classes/StoryPageControl.m
+++ b/clients/ios/Classes/StoryPageControl.m
@@ -983,6 +983,9 @@
     [self.previousPage changeFontSize:fontSize];
 }
 
+#pragma mark -
+#pragma mark HUDs
+
 - (void)showShareHUD:(NSString *)msg {
 //    [MBProgressHUD hideHUDForView:self.view animated:NO];
     self.storyHUD = [MBProgressHUD showHUDAddedTo:self.view animated:YES];
@@ -991,6 +994,10 @@
     self.currentPage.noStorySelectedLabel.hidden = YES;
     self.nextPage.noStorySelectedLabel.hidden = YES;
     self.previousPage.noStorySelectedLabel.hidden = YES;
+}
+
+- (void)flashCheckmarkHud:(NSString *)messageType {
+    [[self currentPage] flashCheckmarkHud:messageType];
 }
 
 #pragma mark -

--- a/clients/ios/Other Sources/ShareThis/InstapaperService.m
+++ b/clients/ios/Other Sources/ShareThis/InstapaperService.m
@@ -2,6 +2,8 @@
 
 #import "InstapaperService.h"
 #import "KeychainItemWrapper.h"
+#import "NewsBlurAppDelegate.h"
+#import "StoryPageControl.h"
 
 //Instapaper:Successfully logged in, Pocket: Success
 const int SUCCESS_LOGIN = 200;
@@ -102,7 +104,7 @@ static InstapaperService *_manager;
             [self postToService];
             break;
         case SUCCESS_POSTED:
-            [self showAlertMessageWithTitle:@"Success" Message:@"Successfully Added!"];
+            [[[NewsBlurAppDelegate sharedAppDelegate] storyPageControl] flashCheckmarkHud:@"added"];
             break;
         case BAD_REQUEST_INSTAPAPER:
             [self showAlertMessageWithTitle:@"Error" Message:@"Bad Request"];

--- a/clients/ios/Other Sources/ShareThis/PocketService.m
+++ b/clients/ios/Other Sources/ShareThis/PocketService.m
@@ -3,6 +3,8 @@
 #import "PocketService.h"
 #import "KeychainItemWrapper.h"
 #import "ShareThis.h"
+#import "NewsBlurAppDelegate.h"
+#import "StoryPageControl.h"
 
 //Success login or success posted
 const int SUCCESS = 200;
@@ -109,7 +111,7 @@ static PocketService *_manager;
             // Pocket uses the same status code for both login success and success posted
             if (![[keychain objectForKey:(__bridge id) kSecAttrAccount] isEqualToString:@""]
                 && [keychain objectForKey:(__bridge id)kSecValueData]) {
-                [self showAlertMessageWithTitle:@"Success" Message:@"Successfully Added!"];
+                [[[NewsBlurAppDelegate sharedAppDelegate] storyPageControl] flashCheckmarkHud:@"added"];
             } else {
                 [keychain setObject:self.username forKey:(__bridge id)kSecAttrAccount];
                 [keychain setObject:self.password forKey:(__bridge id)kSecValueData];

--- a/clients/ios/Other Sources/ShareThis/ReadabilityService.m
+++ b/clients/ios/Other Sources/ShareThis/ReadabilityService.m
@@ -3,6 +3,8 @@
 #import "ReadabilityService.h"
 #import "GCOAuth.h"
 #import "ShareThis.h"
+#import "NewsBlurAppDelegate.h"
+#import "StoryPageControl.h"
 
 const int LOGIN_SUCCESS = 200;
 const int BOOKMARK_SUCCESS = 202;
@@ -168,7 +170,7 @@ static ReadabilityService *_manager;
             self.loggingIn = YES;
             break;
         case BOOKMARK_SUCCESS:
-            [self showAlertMessageWithTitle:@"Success" Message:@"Successfully Added!"];
+            [[[NewsBlurAppDelegate sharedAppDelegate] storyPageControl] flashCheckmarkHud:@"added"];
             break;
         case DUPLICATE_BOOKMARK:
             [self showAlertMessageWithTitle:@"Error" Message:@"Bookmark already exists!"];


### PR DESCRIPTION
To avoid having to tap the "Okay" button on successful post to a read later service I have changed it to use the checkmark HUD (analogous to the mark as saved functionality).
