### PR TITLE
Escape output to prevent XSS

### DIFF
--- a/media/js/newsblur/views/feed_title_view.js
+++ b/media/js/newsblur/views/feed_title_view.js
@@ -66,7 +66,7 @@ NEWSBLUR.Views.FeedTitleView = Backbone.View.extend({
           </div>\
           <img class="feed_favicon" src="<%= $.favicon(feed) %>">\
           <span class="feed_title">\
-            <%= feed.get("feed_title") %>\
+            <%- feed.get("feed_title") %>\
             <% if (type == "story") { %>\
                 <div class="NB-feedbar-mark-feed-read"></div>\
             <% } %>\


### PR DESCRIPTION
This should prevent XSS from happening on feed titles. Currently, renaming a feed to `<script>alert('hi');</script>` will cause the code to be evaluated in page. Supposedly, this will fix that.
