### PR TITLE
Android: Unread Counts for Reading Overlay

### DIFF
--- a/clients/android/NewsBlur/res/layout/activity_reading.xml
+++ b/clients/android/NewsBlur/res/layout/activity_reading.xml
@@ -30,6 +30,7 @@
             android:background="@drawable/selector_overlay_bg_left"
             android:textSize="14sp"
             android:padding="6dp"
+            android:layout_marginRight="1dp"
             android:onClick="overlayLeft" />
 
         <Button
@@ -44,5 +45,23 @@
             android:onClick="overlayRight" />
 
     </LinearLayout>
+
+    <TextView
+        android:id="@+id/reading_overlay_count"
+        android:text=""
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginRight="100dp"
+        android:layout_marginBottom="18dp"
+        android:background="@drawable/neutral_count_rect"
+        android:paddingLeft="3dp"
+        android:paddingRight="3dp"
+        android:shadowDy="1"
+        android:shadowRadius="1"
+        android:textColor="@color/white"
+        android:textSize="14sp"
+        android:textStyle="bold" 
+        android:layout_alignParentBottom="true"
+        android:layout_alignParentRight="true" />
 
 </RelativeLayout>

--- a/clients/android/NewsBlur/src/com/newsblur/activity/AllSharedStoriesReading.java
+++ b/clients/android/NewsBlur/src/com/newsblur/activity/AllSharedStoriesReading.java
@@ -38,13 +38,6 @@ public class AllSharedStoriesReading extends Reading {
 	}
 
 	@Override
-	public void onPageSelected(int position) {
-		super.onPageSelected(position);
-		addStoryToMarkAsRead(readingAdapter.getStory(position));
-		checkStoryCount(position);
-	}
-
-	@Override
 	public void triggerRefresh() {
 		triggerRefresh(1);
 	}

--- a/clients/android/NewsBlur/src/com/newsblur/activity/AllStoriesReading.java
+++ b/clients/android/NewsBlur/src/com/newsblur/activity/AllStoriesReading.java
@@ -39,13 +39,6 @@ public class AllStoriesReading extends Reading {
 	}
     
 	@Override
-	public void onPageSelected(int position) {
-		super.onPageSelected(position);
-		addStoryToMarkAsRead(readingAdapter.getStory(position));
-		checkStoryCount(position);
-	}
-
-	@Override
 	public void triggerRefresh() {
 		triggerRefresh(1);
 	}

--- a/clients/android/NewsBlur/src/com/newsblur/activity/FeedReading.java
+++ b/clients/android/NewsBlur/src/com/newsblur/activity/FeedReading.java
@@ -12,6 +12,7 @@ import com.newsblur.domain.Classifier;
 import com.newsblur.domain.Feed;
 import com.newsblur.fragment.SyncUpdateFragment;
 import com.newsblur.service.SyncService;
+import com.newsblur.util.FeedUtils;
 import com.newsblur.util.PrefsUtils;
 import com.newsblur.util.StoryOrder;
 
@@ -45,6 +46,8 @@ public class FeedReading extends Reading {
 		feed = Feed.fromCursor(feedCursor);
 		setTitle(feed.title);
 
+        this.unreadCount = FeedUtils.getFeedUnreadCount(this.feed, this.currentState);
+
 		readingAdapter = new FeedReadingAdapter(getSupportFragmentManager(), feed, stories, classifier);
 
 		setupPager();
@@ -58,15 +61,6 @@ public class FeedReading extends Reading {
 		addStoryToMarkAsRead(readingAdapter.getStory(passedPosition));
 	}
 
-	@Override
-	public void onPageSelected(int position) {
-		super.onPageSelected(position);
-		if (readingAdapter.getStory(position) != null) {
-			addStoryToMarkAsRead(readingAdapter.getStory(position));
-			checkStoryCount(position);
-		}
-	}
-	
 	@Override
 	public void updateAfterSync() {
 		requestedPage = false;
@@ -111,6 +105,5 @@ public class FeedReading extends Reading {
 
 	@Override
 	public void closeAfterUpdate() { }
-
 
 }

--- a/clients/android/NewsBlur/src/com/newsblur/activity/FolderReading.java
+++ b/clients/android/NewsBlur/src/com/newsblur/activity/FolderReading.java
@@ -38,13 +38,6 @@ public class FolderReading extends Reading {
 	}
 
 	@Override
-	public void onPageSelected(int position) {
-		addStoryToMarkAsRead(readingAdapter.getStory(position));
-		checkStoryCount(position);
-		super.onPageSelected(position);
-	}
-
-	@Override
 	public void triggerRefresh() {
 		triggerRefresh(1);
 	}

--- a/clients/android/NewsBlur/src/com/newsblur/activity/SavedStoriesReading.java
+++ b/clients/android/NewsBlur/src/com/newsblur/activity/SavedStoriesReading.java
@@ -30,12 +30,6 @@ public class SavedStoriesReading extends Reading {
 	}
     
 	@Override
-	public void onPageSelected(int position) {
-		super.onPageSelected(position);
-		checkStoryCount(position);
-	}
-
-	@Override
 	public void triggerRefresh() {
 		triggerRefresh(1);
 	}

--- a/clients/android/NewsBlur/src/com/newsblur/activity/SocialFeedReading.java
+++ b/clients/android/NewsBlur/src/com/newsblur/activity/SocialFeedReading.java
@@ -14,6 +14,7 @@ import com.newsblur.database.MixedFeedsReadingAdapter;
 import com.newsblur.domain.SocialFeed;
 import com.newsblur.domain.Story;
 import com.newsblur.service.SyncService;
+import com.newsblur.util.FeedUtils;
 
 public class SocialFeedReading extends Reading {
 
@@ -40,18 +41,13 @@ public class SocialFeedReading extends Reading {
 		stories = contentResolver.query(storiesURI, null, DatabaseConstants.getStorySelectionFromState(currentState), null, null);
 		setTitle(getIntent().getStringExtra(EXTRA_USERNAME));
 
+        this.unreadCount = FeedUtils.getFeedUnreadCount(this.socialFeed, this.currentState);
+
 		readingAdapter = new MixedFeedsReadingAdapter(getSupportFragmentManager(), getContentResolver(), stories);
 
 		setupPager();
 
 		addStoryToMarkAsRead(readingAdapter.getStory(passedPosition));
-	}
-
-	@Override
-	public void onPageSelected(int position) {
-		super.onPageSelected(position);
-        addStoryToMarkAsRead(readingAdapter.getStory(position));
-		checkStoryCount(position);
 	}
 
 	@Override

--- a/clients/android/NewsBlur/src/com/newsblur/util/AppConstants.java
+++ b/clients/android/NewsBlur/src/com/newsblur/util/AppConstants.java
@@ -5,7 +5,7 @@ public class AppConstants {
     // Enables high-volume logging that may be useful for debugging. This should
     // never be enabled for releases, as it not only slows down the app considerably,
     // it will log sensitive info such as passwords!
-    public static final boolean VERBOSE_LOG = false;
+    public static final boolean VERBOSE_LOG = true;
 
 	public static final int STATE_ALL = 0;
 	public static final int STATE_SOME = 1;

--- a/clients/android/NewsBlur/src/com/newsblur/util/FeedUtils.java
+++ b/clients/android/NewsBlur/src/com/newsblur/util/FeedUtils.java
@@ -23,11 +23,14 @@ import com.newsblur.R;
 import com.newsblur.database.DatabaseConstants;
 import com.newsblur.database.FeedProvider;
 import com.newsblur.domain.Classifier;
+import com.newsblur.domain.Feed;
+import com.newsblur.domain.SocialFeed;
 import com.newsblur.domain.Story;
 import com.newsblur.domain.ValueMultimap;
 import com.newsblur.network.APIManager;
 import com.newsblur.network.domain.NewsBlurResponse;
 import com.newsblur.service.SyncService;
+import com.newsblur.util.AppConstants;
 
 public class FeedUtils {
 
@@ -202,4 +205,34 @@ public class FeedUtils {
         }
 
     }
+
+    /** 
+     * Gets the unread story count for a feed, filtered by view state.
+     */
+    public static int getFeedUnreadCount(Feed feed, int currentState) {
+        if (feed == null ) return 0;
+        int count = 0;
+        count += feed.positiveCount;
+        if ((currentState == AppConstants.STATE_ALL) || (currentState ==  AppConstants.STATE_SOME)) {
+            count += feed.neutralCount;
+        }
+        if (currentState ==  AppConstants.STATE_ALL ) {
+            count += feed.negativeCount;
+        }
+        return count;
+    }
+
+    public static int getFeedUnreadCount(SocialFeed feed, int currentState) {
+        if (feed == null ) return 0;
+        int count = 0;
+        count += feed.positiveCount;
+        if ((currentState == AppConstants.STATE_ALL) || (currentState ==  AppConstants.STATE_SOME)) {
+            count += feed.neutralCount;
+        }
+        if (currentState ==  AppConstants.STATE_ALL ) {
+            count += feed.negativeCount;
+        }
+        return count;
+    }
+        
 }

--- a/clients/android/NewsBlur/src/com/newsblur/util/ViewUtils.java
+++ b/clients/android/NewsBlur/src/com/newsblur/util/ViewUtils.java
@@ -84,27 +84,19 @@ public class ViewUtils {
 
 		TextView tagText = (TextView) v.findViewById(R.id.tag_text);
         
-        // due to a framework bug, the below modification of background resource also resets the declared
-        // padding on the view.  save a copy of said padding so it can be re-applied after the change.
-        int oldPadL = v.getPaddingLeft();
-        int oldPadT = v.getPaddingTop();
-        int oldPadR = v.getPaddingRight();
-        int oldPadB = v.getPaddingBottom();
-
 		tagText.setText(tag);
 
 		if (classifier != null && classifier.tags.containsKey(tag)) {
 			switch (classifier.tags.get(tag)) {
 			case Classifier.LIKE:
-                tagText.setBackgroundResource(R.drawable.tag_background_positive);
+                setViewBackground(tagText, R.drawable.tag_background_positive);
                 tagText.setTextColor(tag_green_text);
                 break;
 			case Classifier.DISLIKE:
-                tagText.setBackgroundResource(R.drawable.tag_background_negative);
+                setViewBackground(tagText, R.drawable.tag_background_negative);
                 tagText.setTextColor(tag_red_text);
                 break;
 			}
-            v.setPadding(oldPadL, oldPadT, oldPadR, oldPadB);
 		}
 
 		v.setOnClickListener(new OnClickListener() {
@@ -117,5 +109,22 @@ public class ViewUtils {
 
 		return v;
 	}
+
+    /**
+     * Sets the background resource of a view, working around a platform bug that causes the declared
+     * padding to get reset.
+     */
+    public static void setViewBackground(View v, int resId) {
+        // due to a framework bug, the below modification of background resource also resets the declared
+        // padding on the view.  save a copy of said padding so it can be re-applied after the change.
+        int oldPadL = v.getPaddingLeft();
+        int oldPadT = v.getPaddingTop();
+        int oldPadR = v.getPaddingRight();
+        int oldPadB = v.getPaddingBottom();
+
+        v.setBackgroundResource(resId);
+
+        v.setPadding(oldPadL, oldPadT, oldPadR, oldPadB);
+    }
 
 }


### PR DESCRIPTION
An initial framework for the reading-progress part of the overlay widget.  Indicates progress thru unreads as you read.

Notes:
- I couldn't find any widget like the circular progress indicator used in the iOS overlay, so subbed in the familiar and well-understood unread-count widget used everywhere else on the site/app.
- This patch enables this new part of the overlay for feed reading and blurblog reading.  I will add support for folder reading after context switching back from critical bugs.
