### PR TITLE
Compute feeds menu popover height rather than hard-coding it.

### DIFF
--- a/clients/ios/Classes/NBContainerViewController.m
+++ b/clients/ios/Classes/NBContainerViewController.m
@@ -238,7 +238,8 @@
     popoverController = [[UIPopoverController alloc]
                          initWithContentViewController:appDelegate.feedsMenuViewController];
     [popoverController setDelegate:self];
-    [popoverController setPopoverContentSize:CGSizeMake(200, 76)];
+    int menuCount = [appDelegate.feedsMenuViewController.menuOptions count];
+    [popoverController setPopoverContentSize:CGSizeMake(200, 38 * menuCount)];
     [popoverController presentPopoverFromBarButtonItem:sender
                               permittedArrowDirections:UIPopoverArrowDirectionAny
                                               animated:YES];


### PR DESCRIPTION
"LOG OUT" was not visible on iPad prior to this change.

Reported at https://getsatisfaction.com/newsblur/topics/logout_button_missing_in_ios_beta_for_ipad
