### PR TITLE
Prefer forward secure and ECC cipher suites

### DIFF
--- a/config/nginx.newsblur.conf
+++ b/config/nginx.newsblur.conf
@@ -15,6 +15,11 @@ server {
     # ssl                     on;
     ssl_certificate         /srv/newsblur/config/certificates/newsblur.com.crt;
     ssl_certificate_key     /srv/newsblur/config/certificates/newsblur.com.key;
+    ssl_ciphers "EECDH+ECDSA+AESGCM EECDH+aRSA+AESGCM EECDH+ECDSA+SHA384 \
+EECDH+ECDSA+SHA256 EECDH+aRSA+SHA384 EECDH+aRSA+SHA256 EECDH+aRSA+RC4 \
+EECDH EDH+aRSA RC4 !aNULL !eNULL !LOW !3DES !MD5 !EXP !PSK !SRP !DSS";
+    ssl_prefer_server_ciphers on;
+    ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
 
     client_max_body_size 4M;
     server_name www.newsblur.com newsblur.com dev.newsblur.com *.newsblur.com circularapp.com *.circularapp.com;


### PR DESCRIPTION
I saw https://getsatisfaction.com/newsblur/topics/weak_crypto_available and realized a pull request might better communicate the ease in this improvement.

Configuration changes guided by https://community.qualys.com/blogs/securitylabs/2013/08/05/configuring-apache-nginx-and-openssl-for-forward-secrecy

Test results can be confirmed with https://www.ssllabs.com/ssltest/analyze.html?d=newsblur.com
