### PR TITLE
Android: Workaround buggy text size setting migrations.

### DIFF
--- a/clients/android/NewsBlur/src/com/newsblur/util/PrefsUtils.java
+++ b/clients/android/NewsBlur/src/com/newsblur/util/PrefsUtils.java
@@ -242,7 +242,14 @@ public class PrefsUtils {
     
     public static float getTextSize(Context context) {
         SharedPreferences preferences = context.getSharedPreferences(PrefConstants.PREFERENCES, 0);
-        return preferences.getFloat(PrefConstants.PREFERENCE_TEXT_SIZE, 1.0f);
+        float storedValue = preferences.getFloat(PrefConstants.PREFERENCE_TEXT_SIZE, 1.0f);
+        // some users have wacky, pre-migration values stored that won't render.  If the value is below our
+        // minimum size, soft reset to the defaul size.
+        if (storedValue < AppConstants.READING_FONT_SIZE[0]) {
+            return 1.0f;
+        } else {
+            return storedValue;
+        }
     }
 
     public static void setTextSize(Context context, float size) {


### PR DESCRIPTION
Quick fix to patch up any users who had their text sizing incorrectly migrated and haven't already used the manual workaround.
