### PR TITLE
Avoid inactive users to login on API

### DIFF
--- a/apps/api/views.py
+++ b/apps/api/views.py
@@ -40,7 +40,7 @@ def login(request):
                 logging.user(request, "~FG~BB~SKAPI Login~SN~FW: %s" % user_agent)
                 code = 1
             else:
-                errors = dict(user="User acount is still inactive. Wait for queue to finish.")
+                errors = dict(user="User account is still inactive. Wait for queue to finish.")
     else:
         errors = dict(method="Invalid method. Use POST. You used %s" % request.method)
         


### PR DESCRIPTION
An example if you are on queue to be provisioned, on mobile apps you still can login, add feeds, read stuff, etc...
