### PR TITLE
Fix @samuelclay image in footer: orig. URL changed

### DIFF
--- a/templates/reader/welcome.xhtml
+++ b/templates/reader/welcome.xhtml
@@ -263,7 +263,7 @@
             <a href="{% url "index" %}"><img src="{{ MEDIA_URL }}/img/logo_newsblur_blur.png" style="height: 32px;" class="NB-footer-logo" title="NewsBlur" alt="NewsBlur" /></a>
             is built in New York City and San Francisco by 
             <a href="http://twitter.com/samuelclay" class="NB-splash-link">
-                <img src="http://a0.twimg.com/profile_images/1382021023/Campeche_Steps_reasonably_small.jpg" class="NB-twitter-avatar">
+                <img src="https://pbs.twimg.com/profile_images/1382021023/Campeche_Steps_reasonably_small.jpg" class="NB-twitter-avatar">
                 @samuelclay
             </a>
         </div>


### PR DESCRIPTION
This is a small one to be sure, but the recent commit (940fe4c) called my attention to the welcome page, and when I saw the image at the bottom fail to load (perhaps this works if logged into Twitter?), I thought I'd try my hand at correcting this.

Cheers,
John Silvestri
