### PR TITLE
Fix #512. Hide immersive single tap preference on pre-4.4 devices.

### DIFF
--- a/clients/android/NewsBlur/res/layout/activity_settings.xml
+++ b/clients/android/NewsBlur/res/layout/activity_settings.xml
@@ -20,7 +20,8 @@
 
     </PreferenceCategory>
     <PreferenceCategory
-        android:title="@string/settings_reading">
+        android:title="@string/settings_reading"
+        android:key="reading">
         <CheckBoxPreference
             android:defaultValue="false"
             android:key="immersive_enter_single_tap"

--- a/clients/android/NewsBlur/src/com/newsblur/activity/Settings.java
+++ b/clients/android/NewsBlur/src/com/newsblur/activity/Settings.java
@@ -3,8 +3,10 @@ package com.newsblur.activity;
 import com.newsblur.R;
 import com.newsblur.util.PrefConstants;
 
+import android.os.Build;
 import android.os.Bundle;
 import android.preference.PreferenceActivity;
+import android.preference.PreferenceCategory;
 import android.view.MenuItem;
 
 public class Settings extends PreferenceActivity {
@@ -15,6 +17,13 @@ public class Settings extends PreferenceActivity {
         getActionBar().setDisplayHomeAsUpEnabled(true);
         super.getPreferenceManager().setSharedPreferencesName(PrefConstants.PREFERENCES);
         addPreferencesFromResource(R.layout.activity_settings);
+
+        // Remove the reading category of references on pre-4.4 devices as it only contains
+        // the single tap for immersive preference
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.KITKAT) {
+            PreferenceCategory readingCategory = (PreferenceCategory)findPreference("reading");
+            getPreferenceScreen().removePreference(readingCategory);
+        }
     }
 
     @Override


### PR DESCRIPTION
As above.
