### PR TITLE
Android: Don't Corrupt Reading Fragments in Background

### DIFF
--- a/clients/android/NewsBlur/src/com/newsblur/activity/ReadingAdapter.java
+++ b/clients/android/NewsBlur/src/com/newsblur/activity/ReadingAdapter.java
@@ -108,12 +108,18 @@ public abstract class ReadingAdapter extends FragmentStatePagerAdapter {
         return frag.get();
     }
 
-    public void updateAllFragments() {
-        for (int i=0; i<cachedFragments.size(); i++) {
+    @Override
+    public void notifyDataSetChanged() {
+        super.notifyDataSetChanged();
+
+        // go one step further than the default pageradapter and also refresh the
+        // story object inside each fragment we have active
+        for (int i=0; i<stories.getCount(); i++) {
             WeakReference<ReadingItemFragment> frag = cachedFragments.get(i);
             if (frag == null) continue;
             ReadingItemFragment rif = frag.get();
             if (rif == null) continue;
+            rif.offerStoryUpdate(getStory(i));
             rif.handleUpdate();
         }
     }

--- a/clients/android/NewsBlur/src/com/newsblur/fragment/ReadingItemFragment.java
+++ b/clients/android/NewsBlur/src/com/newsblur/fragment/ReadingItemFragment.java
@@ -276,22 +276,13 @@ public class ReadingItemFragment extends NbFragment implements ClassifierDialogF
 		});
 	}
 
-    public void updateSaveButton() {
+    private void updateSaveButton() {
         if (view == null) { return; }
 		Button saveButton = (Button) view.findViewById(R.id.save_story_button);
         if (saveButton == null) { return; }
         saveButton.setText(story.starred ? R.string.unsave_this : R.string.save_this);
     }
 
-    public void updateStory(Story story) {
-        if (story != null ) {
-            this.story = story;
-            if (selectedFeedView == DefaultFeedView.TEXT && originalText == null) {
-                loadOriginalText();
-            }
-        }
-    }
-    
 	private void setupShareButton() {
 		Button shareButton = (Button) view.findViewById(R.id.share_story_button);
 
@@ -450,7 +441,19 @@ public class ReadingItemFragment extends NbFragment implements ClassifierDialogF
         ((Reading) parent).enableLeftProgressCircle(loading);
     }
 
+    /** 
+     * Lets the pager offer us an updated version of our story when a new cursor is
+     * cycled in. This class takes the responsibility of ensureing that the cursor
+     * index has not shifted, though, by checking story IDs.
+     */
+    public void offerStoryUpdate(Story story) {
+        if (story == null) return;
+        if (! TextUtils.equals(story.storyHash, this.story.storyHash)) return;
+        this.story = story;
+    }
+
     public void handleUpdate() {
+        updateSaveButton();
         reloadStoryContent();
     }
 


### PR DESCRIPTION
Improve the sync->activity->adapter->fragment update chain to be more hands-off and prevent accidental swapping-in of mismatched story text.

This is a really rare bug introduced in the Beta, but it is also a really bad UX.
