### PR TITLE
Fix full bleed images on iPad portrait with story list at bottom.

### DIFF
--- a/clients/ios/static/storyDetailView.css
+++ b/clients/ios/static/storyDetailView.css
@@ -560,6 +560,11 @@ div + p {
     margin-left: -30px !important;
     width: 736px !important;
 }
+.NB-width-768 .NB-story img.NB-large-image {
+    max-width: 768px;
+    margin-left: -30px !important;
+    width: 768px !important;
+}
 
 .NB-story img.NB-small-image {
     display: inline-block;


### PR DESCRIPTION
Finally got a bit of time to fix this.  An example of what was broken:

![img_0630](https://cloud.githubusercontent.com/assets/68303/5058838/f208ac94-6cd0-11e4-853e-053eec20e7ba.PNG)

It might make sense to just get rid of the -narrow and -wide stuff for full bleed images and just use numeric widths everywhere; for example I noticed while debugging this that the "500 px" width is actually 499 px.
