### PR TITLE
Android: Change mark previous/next as read order

### DIFF
--- a/clients/android/NewsBlur/res/menu/context_story_newest.xml
+++ b/clients/android/NewsBlur/res/menu/context_story_newest.xml
@@ -11,10 +11,10 @@
           android:title="@string/menu_mark_story_as_read" />
     
     <item android:id="@+id/menu_mark_newer_stories_as_read"
-          android:title="@string/menu_mark_newer_stories_as_read" />
+          android:title="@string/menu_newest_mark_newer_stories_as_read" />
 
     <item android:id="@+id/menu_mark_older_stories_as_read"
-          android:title="@string/menu_mark_older_stories_as_read" />
+          android:title="@string/menu_newest_mark_older_stories_as_read" />
 
     <item android:id="@+id/menu_save_story"
           android:title="@string/menu_save_story" />

--- a/clients/android/NewsBlur/res/menu/context_story_oldest.xml
+++ b/clients/android/NewsBlur/res/menu/context_story_oldest.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android" >
+    
+    <item android:id="@+id/menu_shared"
+        android:title="@string/menu_share"/>
+
+    <item android:id="@+id/menu_mark_story_as_unread"
+          android:title="@string/menu_mark_unread" />
+
+    <item android:id="@+id/menu_mark_story_as_read"
+          android:title="@string/menu_mark_story_as_read" />
+
+    <item android:id="@+id/menu_mark_older_stories_as_read"
+        android:title="@string/menu_oldest_mark_older_stories_as_read" />
+
+    <item android:id="@+id/menu_mark_newer_stories_as_read"
+          android:title="@string/menu_oldest_mark_newer_stories_as_read" />
+
+    <item android:id="@+id/menu_save_story"
+          android:title="@string/menu_save_story" />
+
+    <item android:id="@+id/menu_unsave_story"
+        android:title="@string/menu_unsave_story" />
+
+</menu>

--- a/clients/android/NewsBlur/res/values/strings.xml
+++ b/clients/android/NewsBlur/res/values/strings.xml
@@ -102,8 +102,10 @@
     <string name="menu_textsize">Adjust text size</string>
     <string name="menu_save_story">Save this story</string>
     <string name="menu_unsave_story">Unsave this story</string>
-    <string name="menu_mark_older_stories_as_read">Mark older as read</string>
-    <string name="menu_mark_newer_stories_as_read">Mark newer as read</string>
+    <string name="menu_newest_mark_older_stories_as_read">\u21E3 Mark older as read</string>
+    <string name="menu_newest_mark_newer_stories_as_read">\u21E1 Mark newer as read</string>
+    <string name="menu_oldest_mark_older_stories_as_read">\u21E1 Mark older as read</string>
+    <string name="menu_oldest_mark_newer_stories_as_read">\u21E3 Mark newer as read</string>
     <string name="menu_mark_story_as_read">Mark as read</string>
     <string name="menu_mark_unread">Mark as unread</string>
     <string name="menu_fullscreen">Full screen</string>

--- a/clients/android/NewsBlur/src/com/newsblur/fragment/ItemListFragment.java
+++ b/clients/android/NewsBlur/src/com/newsblur/fragment/ItemListFragment.java
@@ -31,7 +31,9 @@ import com.newsblur.domain.Story;
 import com.newsblur.util.DefaultFeedView;
 import com.newsblur.util.FeedSet;
 import com.newsblur.util.FeedUtils;
+import com.newsblur.util.PrefsUtils;
 import com.newsblur.util.StateFilter;
+import com.newsblur.util.StoryOrder;
 
 public abstract class ItemListFragment extends NbFragment implements OnScrollListener, OnCreateContextMenuListener, LoaderManager.LoaderCallbacks<Cursor>, OnItemClickListener {
 
@@ -179,7 +181,11 @@ public abstract class ItemListFragment extends NbFragment implements OnScrollLis
     @Override
     public void onCreateContextMenu(ContextMenu menu, View v, ContextMenuInfo menuInfo) {
         MenuInflater inflater = getActivity().getMenuInflater();
-        inflater.inflate(R.menu.context_story, menu);
+        if (PrefsUtils.getStoryOrder(activity, getFeedSet()) == StoryOrder.NEWEST) {
+            inflater.inflate(R.menu.context_story_newest, menu);
+        } else {
+            inflater.inflate(R.menu.context_story_oldest, menu);
+        }
 
         Story story = adapter.getStory(((AdapterView.AdapterContextMenuInfo) (menuInfo)).position);
         if (story.read) {


### PR DESCRIPTION
Fixes #623 

I wasn't particularly keen on duplicating the menu XML but there doesn't seem to be a nice way in the API to reorder or remove then insert menu items at particular indexes etc. so I though this was cleaner.
