### PR TITLE
Fix crash when mailing a URL in the original story view.

### DIFF
--- a/clients/ios/Classes/NBActivityItemProvider.m
+++ b/clients/ios/Classes/NBActivityItemProvider.m
@@ -30,7 +30,7 @@
 -(id)activityViewController:(UIActivityViewController *)activityViewController itemForActivityType:(NSString *)activityType {
     if ([activityType isEqualToString:UIActivityTypeMail] ||
         [activityType isEqualToString:@"com.evernote.iPhone.Evernote.EvernoteShare"]) {
-        return @{@"body": text, @"subject": title};
+        return @{@"body": text ?: @"", @"subject": title};
     } else if ([activityType isEqualToString:UIActivityTypePostToTwitter] ||
                [activityType isEqualToString:UIActivityTypePostToFacebook] ||
                [activityType isEqualToString:UIActivityTypePostToWeibo]) {


### PR DESCRIPTION
[OriginalStoryViewController doOpenActionSheet] calls showSendTo with a nil
text parameter, but [NBActivityItemProvider activityViewController:
itemForActivityType:] returns a dictionary with the text as a value, and
dictionary literals can't use nil values. Use an empty string instead.

Appears to be a regression from 1002403e81087e16695589e7ad1b322856252d40.