### PR TITLE
Android: Fix background colour for blurblog share table in dark theme

### DIFF
--- a/clients/android/NewsBlur/assets/dark_reading.css
+++ b/clients/android/NewsBlur/assets/dark_reading.css
@@ -18,3 +18,7 @@ code {
 pre, blockquote {
     background-color: #4C4C4C;
 }
+
+.NB-story > table {
+    background-color: #4C4C4C !important;
+}


### PR DESCRIPTION
When adding global shared stories I noticed that the table in blurblog stories showing "shared by..." wasn't readable when using the dark theme.

This tweaks the CSS to fix that.