### PR TITLE
Android: Custom ActionBar Styling (and Bugfixes)

### DIFF
--- a/clients/android/NewsBlur/res/layout/actionbar_custom_icon.xml
+++ b/clients/android/NewsBlur/res/layout/actionbar_custom_icon.xml
@@ -5,8 +5,8 @@
 
     <ImageView
         android:id="@+id/actionbar_icon"
-        android:layout_width="25dp"
-        android:layout_height="25dp"
+        android:layout_width="24dp"
+        android:layout_height="24dp"
         android:layout_alignParentLeft="true"
         android:layout_centerVertical="true"
         android:layout_marginLeft="10dp"

--- a/clients/android/NewsBlur/res/layout/actionbar_custom_icon.xml
+++ b/clients/android/NewsBlur/res/layout/actionbar_custom_icon.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="fill_parent"
+    android:layout_height="fill_parent" >
+
+    <ImageView
+        android:id="@+id/actionbar_icon"
+        android:layout_width="25dp"
+        android:layout_height="25dp"
+        android:layout_alignParentLeft="true"
+        android:layout_centerVertical="true"
+        android:layout_marginLeft="10dp"
+        android:layout_marginRight="4dp"
+        android:src="@drawable/world" />
+
+    <TextView
+        android:id="@+id/actionbar_text"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_centerVertical="true"
+        android:layout_toRightOf="@id/actionbar_icon"
+        android:textSize="18sp" />
+
+</RelativeLayout>

--- a/clients/android/NewsBlur/res/layout/actionbar_custom_icon.xml
+++ b/clients/android/NewsBlur/res/layout/actionbar_custom_icon.xml
@@ -19,6 +19,8 @@
         android:layout_height="wrap_content"
         android:layout_centerVertical="true"
         android:layout_toRightOf="@id/actionbar_icon"
+        android:ellipsize="end"
+        android:maxLines="1"
         android:textSize="18sp" />
 
 </RelativeLayout>

--- a/clients/android/NewsBlur/src/com/newsblur/activity/AllSharedStoriesItemsList.java
+++ b/clients/android/NewsBlur/src/com/newsblur/activity/AllSharedStoriesItemsList.java
@@ -16,6 +16,7 @@ import com.newsblur.util.PrefConstants;
 import com.newsblur.util.PrefsUtils;
 import com.newsblur.util.ReadFilter;
 import com.newsblur.util.StoryOrder;
+import com.newsblur.util.UIUtils;
 
 public class AllSharedStoriesItemsList extends ItemsList {
 
@@ -23,7 +24,7 @@ public class AllSharedStoriesItemsList extends ItemsList {
 	protected void onCreate(Bundle bundle) {
 		super.onCreate(bundle);
 
-		setTitle(getResources().getString(R.string.all_shared_stories));
+        UIUtils.setCustomActionBar(this, R.drawable.ak_icon_blurblogs, getResources().getString(R.string.all_shared_stories));
 
 		itemListFragment = (AllSharedStoriesItemListFragment) fragmentManager.findFragmentByTag(AllSharedStoriesItemListFragment.class.getName());
 		if (itemListFragment == null) {

--- a/clients/android/NewsBlur/src/com/newsblur/activity/AllSharedStoriesReading.java
+++ b/clients/android/NewsBlur/src/com/newsblur/activity/AllSharedStoriesReading.java
@@ -4,6 +4,7 @@ import android.os.Bundle;
 
 import com.newsblur.R;
 import com.newsblur.database.MixedFeedsReadingAdapter;
+import com.newsblur.util.UIUtils;
 
 public class AllSharedStoriesReading extends Reading {
 
@@ -11,7 +12,7 @@ public class AllSharedStoriesReading extends Reading {
     protected void onCreate(Bundle savedInstanceBundle) {
         super.onCreate(savedInstanceBundle);
 
-        setTitle(getResources().getString(R.string.all_shared_stories));
+        UIUtils.setCustomActionBar(this, R.drawable.ak_icon_blurblogs, getResources().getString(R.string.all_shared_stories));
 
         // No sourceUserId since this is all shared stories. The sourceUsedId for each story will be used.
         readingAdapter = new MixedFeedsReadingAdapter(getFragmentManager(), defaultFeedView, null);

--- a/clients/android/NewsBlur/src/com/newsblur/activity/AllStoriesItemsList.java
+++ b/clients/android/NewsBlur/src/com/newsblur/activity/AllStoriesItemsList.java
@@ -20,6 +20,7 @@ import com.newsblur.util.PrefsUtils;
 import com.newsblur.util.ReadFilter;
 import com.newsblur.util.StoryOrder;
 import com.newsblur.util.StateFilter;
+import com.newsblur.util.UIUtils;
 
 public class AllStoriesItemsList extends ItemsList implements MarkAllReadDialogListener {
 
@@ -27,7 +28,7 @@ public class AllStoriesItemsList extends ItemsList implements MarkAllReadDialogL
 	protected void onCreate(Bundle bundle) {
 		super.onCreate(bundle);
 
-		setTitle(getResources().getString(R.string.all_stories));
+        UIUtils.setCustomActionBar(this, R.drawable.ak_icon_allstories, getResources().getString(R.string.all_stories));
 
 		itemListFragment = (AllStoriesItemListFragment) fragmentManager.findFragmentByTag(AllStoriesItemListFragment.class.getName());
 		if (itemListFragment == null) {

--- a/clients/android/NewsBlur/src/com/newsblur/activity/AllStoriesReading.java
+++ b/clients/android/NewsBlur/src/com/newsblur/activity/AllStoriesReading.java
@@ -4,6 +4,7 @@ import android.os.Bundle;
 
 import com.newsblur.R;
 import com.newsblur.database.MixedFeedsReadingAdapter;
+import com.newsblur.util.UIUtils;
 
 public class AllStoriesReading extends Reading {
 
@@ -11,6 +12,7 @@ public class AllStoriesReading extends Reading {
     protected void onCreate(Bundle savedInstanceBundle) {
         super.onCreate(savedInstanceBundle);
 
+        UIUtils.setCustomActionBar(this, R.drawable.ak_icon_allstories, getResources().getString(R.string.all_stories_row_title));
         setTitle(getResources().getString(R.string.all_stories_row_title));
         readingAdapter = new MixedFeedsReadingAdapter(getFragmentManager(), defaultFeedView, null);
         getLoaderManager().initLoader(0, null, this);

--- a/clients/android/NewsBlur/src/com/newsblur/activity/FeedItemsList.java
+++ b/clients/android/NewsBlur/src/com/newsblur/activity/FeedItemsList.java
@@ -33,8 +33,7 @@ public class FeedItemsList extends ItemsList {
         
 		super.onCreate(bundle);
 
-        setTitle(feed.title);
-        UIUtils.setActionBarImage(this, feed.faviconUrl);
+        UIUtils.setCustomActionBar(this, feed.faviconUrl, feed.title);
 
 		itemListFragment = (FeedItemListFragment) fragmentManager.findFragmentByTag(FeedItemListFragment.class.getName());
 		if (itemListFragment == null) {

--- a/clients/android/NewsBlur/src/com/newsblur/activity/FeedReading.java
+++ b/clients/android/NewsBlur/src/com/newsblur/activity/FeedReading.java
@@ -20,8 +20,7 @@ public class FeedReading extends Reading {
 
         Classifier classifier = FeedUtils.dbHelper.getClassifierForFeed(feed.feedId);
 
-        setTitle(feed.title);
-        UIUtils.setActionBarImage(this, feed.faviconUrl);
+        UIUtils.setCustomActionBar(this, feed.faviconUrl, feed.title);
 
         readingAdapter = new FeedReadingAdapter(fragmentManager, feed, classifier, defaultFeedView);
 

--- a/clients/android/NewsBlur/src/com/newsblur/activity/FolderItemsList.java
+++ b/clients/android/NewsBlur/src/com/newsblur/activity/FolderItemsList.java
@@ -26,6 +26,7 @@ import com.newsblur.util.PrefsUtils;
 import com.newsblur.util.ReadFilter;
 import com.newsblur.util.StateFilter;
 import com.newsblur.util.StoryOrder;
+import com.newsblur.util.UIUtils;
 
 public class FolderItemsList extends ItemsList implements MarkAllReadDialogListener {
 
@@ -39,7 +40,7 @@ public class FolderItemsList extends ItemsList implements MarkAllReadDialogListe
         // note: onCreate triggers createFeedSet() so it has to wait until we have the folder name
 		super.onCreate(bundle);
 
-		setTitle(folderName);
+        UIUtils.setCustomActionBar(this, R.drawable.g_icn_folder_rss, folderName);
 
 		itemListFragment = (FolderItemListFragment) fragmentManager.findFragmentByTag(FolderItemListFragment.class.getName());
 		if (itemListFragment == null) {

--- a/clients/android/NewsBlur/src/com/newsblur/activity/FolderReading.java
+++ b/clients/android/NewsBlur/src/com/newsblur/activity/FolderReading.java
@@ -2,7 +2,9 @@ package com.newsblur.activity;
 
 import android.os.Bundle;
 
+import com.newsblur.R;
 import com.newsblur.database.MixedFeedsReadingAdapter;
+import com.newsblur.util.UIUtils;
 
 public class FolderReading extends Reading {
 
@@ -13,7 +15,7 @@ public class FolderReading extends Reading {
         super.onCreate(savedInstanceBundle);
 
         folderName = getIntent().getStringExtra(Reading.EXTRA_FOLDERNAME);
-        setTitle(folderName);       
+        UIUtils.setCustomActionBar(this, R.drawable.g_icn_folder_rss, folderName);
 
         readingAdapter = new MixedFeedsReadingAdapter(getFragmentManager(), defaultFeedView, null);
 

--- a/clients/android/NewsBlur/src/com/newsblur/activity/GlobalSharedStoriesItemsList.java
+++ b/clients/android/NewsBlur/src/com/newsblur/activity/GlobalSharedStoriesItemsList.java
@@ -13,6 +13,7 @@ import com.newsblur.util.PrefConstants;
 import com.newsblur.util.PrefsUtils;
 import com.newsblur.util.ReadFilter;
 import com.newsblur.util.StoryOrder;
+import com.newsblur.util.UIUtils;
 
 public class GlobalSharedStoriesItemsList extends ItemsList {
 
@@ -20,7 +21,7 @@ public class GlobalSharedStoriesItemsList extends ItemsList {
 	protected void onCreate(Bundle bundle) {
 		super.onCreate(bundle);
 
-		setTitle(getResources().getString(R.string.global_shared_stories));
+        UIUtils.setCustomActionBar(this, R.drawable.ak_icon_global, getResources().getString(R.string.global_shared_stories));
 
 		itemListFragment = (GlobalSharedStoriesItemListFragment) fragmentManager.findFragmentByTag(GlobalSharedStoriesItemListFragment.class.getName());
 		if (itemListFragment == null) {

--- a/clients/android/NewsBlur/src/com/newsblur/activity/GlobalSharedStoriesReading.java
+++ b/clients/android/NewsBlur/src/com/newsblur/activity/GlobalSharedStoriesReading.java
@@ -5,6 +5,7 @@ import android.view.Menu;
 
 import com.newsblur.R;
 import com.newsblur.database.MixedFeedsReadingAdapter;
+import com.newsblur.util.UIUtils;
 
 public class GlobalSharedStoriesReading extends Reading {
 
@@ -12,7 +13,7 @@ public class GlobalSharedStoriesReading extends Reading {
     protected void onCreate(Bundle savedInstanceBundle) {
         super.onCreate(savedInstanceBundle);
 
-        setTitle(getResources().getString(R.string.global_shared_stories));
+        UIUtils.setCustomActionBar(this, R.drawable.ak_icon_global, getResources().getString(R.string.global_shared_stories));
         readingAdapter = new MixedFeedsReadingAdapter(getFragmentManager(), defaultFeedView, null);
 
         getLoaderManager().initLoader(0, null, this);

--- a/clients/android/NewsBlur/src/com/newsblur/activity/ItemsList.java
+++ b/clients/android/NewsBlur/src/com/newsblur/activity/ItemsList.java
@@ -54,13 +54,10 @@ public abstract class ItemsList extends NbActivity implements StateChangedListen
 		currentState = (StateFilter) getIntent().getSerializableExtra(EXTRA_STATE);
         this.fs = createFeedSet();
 
-		requestWindowFeature(Window.FEATURE_PROGRESS);
         getWindow().setBackgroundDrawableResource(android.R.color.transparent);
 
 		setContentView(R.layout.activity_itemslist);
 		fragmentManager = getFragmentManager();
-
-		getActionBar().setDisplayHomeAsUpEnabled(true);
 
         this.overlayStatusText = (TextView) findViewById(R.id.itemlist_sync_status);
 	}

--- a/clients/android/NewsBlur/src/com/newsblur/activity/Reading.java
+++ b/clients/android/NewsBlur/src/com/newsblur/activity/Reading.java
@@ -137,8 +137,6 @@ public abstract class Reading extends NbActivity implements OnPageChangeListener
             defaultFeedView = (DefaultFeedView) getIntent().getSerializableExtra(EXTRA_DEFAULT_FEED_VIEW);
         }
 
-        getActionBar().setDisplayHomeAsUpEnabled(true);
-
         // this value is expensive to compute but doesn't change during a single runtime
         this.overlayRangeTopPx = (float) UIUtils.convertDPsToPixels(this, OVERLAY_RANGE_TOP_DP);
         this.overlayRangeBotPx = (float) UIUtils.convertDPsToPixels(this, OVERLAY_RANGE_BOT_DP);

--- a/clients/android/NewsBlur/src/com/newsblur/activity/ReadingAdapter.java
+++ b/clients/android/NewsBlur/src/com/newsblur/activity/ReadingAdapter.java
@@ -82,6 +82,7 @@ public abstract class ReadingAdapter extends FragmentStatePagerAdapter {
 	}
 
     public synchronized int getPosition(Story story) {
+        if (stories == null) return -1;
         int pos = 0;
         while (pos < stories.getCount()) {
 			stories.moveToPosition(pos);

--- a/clients/android/NewsBlur/src/com/newsblur/activity/SavedStoriesItemsList.java
+++ b/clients/android/NewsBlur/src/com/newsblur/activity/SavedStoriesItemsList.java
@@ -16,6 +16,7 @@ import com.newsblur.util.PrefConstants;
 import com.newsblur.util.PrefsUtils;
 import com.newsblur.util.ReadFilter;
 import com.newsblur.util.StoryOrder;
+import com.newsblur.util.UIUtils;
 
 public class SavedStoriesItemsList extends ItemsList {
 
@@ -23,7 +24,7 @@ public class SavedStoriesItemsList extends ItemsList {
 	protected void onCreate(Bundle bundle) {
 		super.onCreate(bundle);
 
-		setTitle(getResources().getString(R.string.saved_stories_title));
+        UIUtils.setCustomActionBar(this, R.drawable.clock, getResources().getString(R.string.saved_stories_title));
 
 		itemListFragment = (SavedStoriesItemListFragment) fragmentManager.findFragmentByTag(SavedStoriesItemListFragment.class.getName());
 		if (itemListFragment == null) {

--- a/clients/android/NewsBlur/src/com/newsblur/activity/SavedStoriesReading.java
+++ b/clients/android/NewsBlur/src/com/newsblur/activity/SavedStoriesReading.java
@@ -7,6 +7,7 @@ import android.content.Loader;
 import com.newsblur.R;
 import com.newsblur.database.MixedFeedsReadingAdapter;
 import com.newsblur.util.FeedUtils;
+import com.newsblur.util.UIUtils;
 
 public class SavedStoriesReading extends Reading {
 
@@ -14,7 +15,7 @@ public class SavedStoriesReading extends Reading {
     protected void onCreate(Bundle savedInstanceBundle) {
         super.onCreate(savedInstanceBundle);
 
-        setTitle(getResources().getString(R.string.saved_stories_title));
+        UIUtils.setCustomActionBar(this, R.drawable.clock, getResources().getString(R.string.saved_stories_title));
         readingAdapter = new MixedFeedsReadingAdapter(getFragmentManager(), defaultFeedView, null);
 
         getLoaderManager().initLoader(0, null, this);

--- a/clients/android/NewsBlur/src/com/newsblur/activity/SocialFeedItemsList.java
+++ b/clients/android/NewsBlur/src/com/newsblur/activity/SocialFeedItemsList.java
@@ -32,8 +32,7 @@ public class SocialFeedItemsList extends ItemsList {
 	    socialFeed = (SocialFeed) getIntent().getSerializableExtra(EXTRA_SOCIAL_FEED);
 		super.onCreate(bundle);
 				
-		setTitle(socialFeed.feedTitle);
-        UIUtils.setActionBarImage(this, socialFeed.photoUrl);
+        UIUtils.setCustomActionBar(this, socialFeed.photoUrl, socialFeed.feedTitle);
 		
 		if (itemListFragment == null) {
 			itemListFragment = SocialFeedItemListFragment.newInstance(socialFeed, currentState, getDefaultFeedView());

--- a/clients/android/NewsBlur/src/com/newsblur/activity/SocialFeedReading.java
+++ b/clients/android/NewsBlur/src/com/newsblur/activity/SocialFeedReading.java
@@ -16,8 +16,7 @@ public class SocialFeedReading extends Reading {
 
 	    socialFeed = (SocialFeed) getIntent().getSerializableExtra(EXTRA_SOCIAL_FEED);
 
-        setTitle(socialFeed.feedTitle);
-        UIUtils.setActionBarImage(this, socialFeed.photoUrl);
+        UIUtils.setCustomActionBar(this, socialFeed.photoUrl, socialFeed.feedTitle);
 
         readingAdapter = new MixedFeedsReadingAdapter(getFragmentManager(), defaultFeedView, socialFeed.userId);
 

--- a/clients/android/NewsBlur/src/com/newsblur/network/APIManager.java
+++ b/clients/android/NewsBlur/src/com/newsblur/network/APIManager.java
@@ -83,6 +83,9 @@ public class APIManager {
 	}
 
 	public NewsBlurResponse login(final String username, final String password) {
+        // This call should be pretty rare, but is expensive on the server side.  Log it
+        // at an above-debug level so it will be noticed if it ever gets called too often.
+        Log.i(this.getClass().getName(), "calling login API");
 		final ContentValues values = new ContentValues();
 		values.put(APIConstants.PARAMETER_USERNAME, username);
 		values.put(APIConstants.PARAMETER_PASSWORD, password);

--- a/clients/android/NewsBlur/src/com/newsblur/util/PrefsUtils.java
+++ b/clients/android/NewsBlur/src/com/newsblur/util/PrefsUtils.java
@@ -81,6 +81,7 @@ public class PrefsUtils {
         s.append("%0Aapp version: ").append(getVersion(context));
         s.append("%0Aandroid version: ").append(Build.VERSION.RELEASE);
         s.append("%0Adevice: ").append(Build.MANUFACTURER + "+" + Build.MODEL + "+(" + Build.BOARD + ")");
+        s.append("%0Ausername: ").append(getUserDetails(context).username);
         s.append("%0Amemory: ").append(NBSyncService.isMemoryLow() ? "low" : "normal");
         s.append("%0Aspeed: ").append(NBSyncService.getSpeedInfo());
         s.append("%0Apremium: ");

--- a/clients/android/NewsBlur/src/com/newsblur/util/UIUtils.java
+++ b/clients/android/NewsBlur/src/com/newsblur/util/UIUtils.java
@@ -5,6 +5,7 @@ import static android.graphics.Color.WHITE;
 import static android.graphics.PorterDuff.Mode.DST_IN;
 
 import android.app.Activity;
+import android.app.ActionBar;
 import android.content.Context;
 import android.content.Intent;
 import android.content.res.TypedArray;
@@ -17,9 +18,15 @@ import android.graphics.drawable.BitmapDrawable;
 import android.os.AsyncTask;
 import android.os.Build;
 import android.os.Handler;
+import android.view.LayoutInflater;
 import android.view.View;
+import android.view.View.OnClickListener;
+import android.view.ViewGroup.LayoutParams;
+import android.widget.ImageView;
+import android.widget.TextView;
 import android.widget.Toast;
 
+import com.newsblur.R;
 import com.newsblur.activity.NewsBlurApplication;
 
 public class UIUtils {
@@ -80,35 +87,28 @@ public class UIUtils {
         }
     }
 
-    public static int getActionBarHeight(Context context) {    
-        TypedArray atts = context.getTheme().obtainStyledAttributes(new int[] { android.R.attr.actionBarSize });
-        int h = (int) atts.getDimension(0, 0);
-        atts.recycle();
-        return h;
-    }
-
-    public static void setActionBarImage(final Activity activity, final String url) { 
-        new AsyncTask<Void, Void, Void>() {
+    public static void setCustomActionBar(final Activity activity, String url, String title) { 
+        activity.getActionBar().setDisplayShowCustomEnabled(true);
+        activity.getActionBar().setDisplayShowTitleEnabled(false);
+        activity.getActionBar().setDisplayShowHomeEnabled(false);
+        View v = LayoutInflater.from(activity).inflate(R.layout.actionbar_custom_icon, null);
+        TextView titleView = ((TextView) v.findViewById(R.id.actionbar_text));
+        titleView.setText(title);
+        titleView.setOnClickListener(new OnClickListener() {
             @Override
-            protected Void doInBackground(Void... arg) {
-                Bitmap icon = ((NewsBlurApplication) activity.getApplicationContext()).getImageLoader().tryGetImage(url);
-                if (icon != null) {
-                    // If setLogo() is called with a raw image, it isn't scaled up or down, but drawn raw. Wrapping
-                    // the icon in a BitmapDrawable lets it scale up.  Note, though, that the iconSize is actually
-                    // ignored on virtually all platforms and the actionbar re-resizes it up to full height, so 
-                    // attempting to add padding will silently fail.
-                    int iconSize = getActionBarHeight(activity);
-                    Bitmap scaledIcon = Bitmap.createScaledBitmap(icon, iconSize, iconSize, false);
-                    final BitmapDrawable draw = new BitmapDrawable(activity.getResources(), scaledIcon);
-                    activity.runOnUiThread(new Runnable() {
-                        public void run() {
-                            activity.getActionBar().setLogo(draw);
-                        }
-                    });
-                }
-                return null;
+            public void onClick(View v) {
+                activity.finish();
             }
-        }.execute();
+        });
+        ImageView iconView = ((ImageView) v.findViewById(R.id.actionbar_icon));
+        ((NewsBlurApplication) activity.getApplicationContext()).getImageLoader().displayImage(url, iconView, false);
+        iconView.setOnClickListener(new OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                activity.finish();
+            }
+        });
+        activity.getActionBar().setCustomView(v, new ActionBar.LayoutParams(LayoutParams.WRAP_CONTENT, LayoutParams.FILL_PARENT));
     }
 
     /**

--- a/clients/android/NewsBlur/src/com/newsblur/util/UIUtils.java
+++ b/clients/android/NewsBlur/src/com/newsblur/util/UIUtils.java
@@ -87,21 +87,28 @@ public class UIUtils {
         }
     }
 
+    /**
+     * Set up our customised ActionBar view that features the specified icon and title, sized
+     * away from system standard to meet the NewsBlur visual style.
+     */
     public static void setCustomActionBar(final Activity activity, String url, String title) { 
+        // we completely replace the existing title and 'home' icon with a custom view
         activity.getActionBar().setDisplayShowCustomEnabled(true);
         activity.getActionBar().setDisplayShowTitleEnabled(false);
         activity.getActionBar().setDisplayShowHomeEnabled(false);
         View v = LayoutInflater.from(activity).inflate(R.layout.actionbar_custom_icon, null);
         TextView titleView = ((TextView) v.findViewById(R.id.actionbar_text));
         titleView.setText(title);
+        ImageView iconView = ((ImageView) v.findViewById(R.id.actionbar_icon));
+        ((NewsBlurApplication) activity.getApplicationContext()).getImageLoader().displayImage(url, iconView, false);
+        // using a custom view breaks the system-standard ability to tap the icon or title to return
+        // to the previous activity. Re-implement that here.
         titleView.setOnClickListener(new OnClickListener() {
             @Override
             public void onClick(View v) {
                 activity.finish();
             }
         });
-        ImageView iconView = ((ImageView) v.findViewById(R.id.actionbar_icon));
-        ((NewsBlurApplication) activity.getApplicationContext()).getImageLoader().displayImage(url, iconView, false);
         iconView.setOnClickListener(new OnClickListener() {
             @Override
             public void onClick(View v) {

--- a/clients/android/NewsBlur/src/com/newsblur/util/UIUtils.java
+++ b/clients/android/NewsBlur/src/com/newsblur/util/UIUtils.java
@@ -91,7 +91,17 @@ public class UIUtils {
      * Set up our customised ActionBar view that features the specified icon and title, sized
      * away from system standard to meet the NewsBlur visual style.
      */
-    public static void setCustomActionBar(final Activity activity, String url, String title) { 
+    public static void setCustomActionBar(Activity activity, String imageUrl, String title) { 
+        ImageView iconView = setupCustomActionbar(activity, title);
+        ((NewsBlurApplication) activity.getApplicationContext()).getImageLoader().displayImage(imageUrl, iconView, false);
+    }
+
+    public static void setCustomActionBar(Activity activity, int imageId, String title) { 
+        ImageView iconView = setupCustomActionbar(activity, title);
+        iconView.setImageResource(imageId);
+    }
+
+    private static ImageView setupCustomActionbar(final Activity activity, String title) {
         // we completely replace the existing title and 'home' icon with a custom view
         activity.getActionBar().setDisplayShowCustomEnabled(true);
         activity.getActionBar().setDisplayShowTitleEnabled(false);
@@ -100,7 +110,6 @@ public class UIUtils {
         TextView titleView = ((TextView) v.findViewById(R.id.actionbar_text));
         titleView.setText(title);
         ImageView iconView = ((ImageView) v.findViewById(R.id.actionbar_icon));
-        ((NewsBlurApplication) activity.getApplicationContext()).getImageLoader().displayImage(url, iconView, false);
         // using a custom view breaks the system-standard ability to tap the icon or title to return
         // to the previous activity. Re-implement that here.
         titleView.setOnClickListener(new OnClickListener() {
@@ -116,6 +125,7 @@ public class UIUtils {
             }
         });
         activity.getActionBar().setCustomView(v, new ActionBar.LayoutParams(LayoutParams.WRAP_CONTENT, LayoutParams.FILL_PARENT));
+        return iconView;
     }
 
     /**


### PR DESCRIPTION
Replaced the system ActionBar UI with one of our own so we can control the size of the icon in it.  Also added styling for the remaining reading types.

Also inclues a few little bugfixes found over the last week.

Mucking with the ActionBar can be tricky, so I would want to test this out on most of the Android versions we support, 11-22.  I've tested on 19 and 21 and will get 22 tonight.