### PR TITLE
Fix :username typo in api.yml

### DIFF
--- a/templates/static/api.yml
+++ b/templates/static/api.yml
@@ -919,7 +919,7 @@
         - >
           The <code>username</code> url parameter is optional. It's just recommended 
           if you have it.
-    - url: /social/statistics/:user_id/:name
+    - url: /social/statistics/:user_id/:username
       method: GET
       short_desc: "Get statistics and history for a blurblog."
       long_desc: 


### PR DESCRIPTION
I was looking through the API and I noticed that `/social/statistics/:user_id/:name` seems to stand out in regard to the similar endpoints around it.  The other endpoints follow a `/social/something/:user_id/:username` format and they all have a Tip that says "The `username` url parameter is optional. It's just recommended if you have it."

This led me to believe that maybe the `:name` url parameter was maybe just a typo, so here's a pull request that fixes it in case I'm correct in my thinking.