### PR TITLE
Fix release builds that use okhttp. (#680)

### DIFF
--- a/clients/android/NewsBlur/proguard-project.txt
+++ b/clients/android/NewsBlur/proguard-project.txt
@@ -21,3 +21,6 @@
 
 # We're open-source; dont' obfuscate.
 -dontobfuscate
+
+-dontwarn com.squareup.okhttp.**
+-dontwarn okio.**


### PR DESCRIPTION
Added the necessary config so release builds will work with okhttp.