### PR TITLE
Added a workaround for Linux webkit browsers

### DIFF
--- a/media/js/newsblur/models/stories.js
+++ b/media/js/newsblur/models/stories.js
@@ -123,7 +123,16 @@ NEWSBLUR.Models.Story = Backbone.Model.extend({
     open_story_in_new_tab: function(background) {
         this.mark_read({skip_delay: true});
 
-        if (background && !$.browser.mozilla) {
+        // A «Safari» browser on Linux is an impossibility, and thus we're actually
+        // on a WebKit-based browser (WebKitGTK or QTWebKit). These can't handle
+        // background tabs. Work around it by disabling backgrounding if we
+        // think we're on Safari and we're also on X11 or Linux
+        if($.browser.safari && /(\(X11|Linux)/.test(navigator.userAgent))
+        {
+            background = false;
+        }
+
+        if (background && !$.browser.mozilla && trueSafari) {
             var anchor, event;
 
             anchor = document.createElement("a");


### PR DESCRIPTION
This is the issue referred to from https://getsatisfaction.com/newsblur/topics/does-not-open-links-in-new-tabs-in-various-webkit-browsers

Essentially, WebKit-based browsers on Linux can't handle the way NewsBlur attempts to open tabs in the background. This workaround detects those browsers and disables backgrounding for them.