### PR TITLE
Removed an unused variable that broke other browsers

### DIFF
--- a/media/js/newsblur/models/stories.js
+++ b/media/js/newsblur/models/stories.js
@@ -132,7 +132,7 @@ NEWSBLUR.Models.Story = Backbone.Model.extend({
             background = false;
         }
 
-        if (background && !$.browser.mozilla && trueSafari) {
+        if (background && !$.browser.mozilla) {
             var anchor, event;
 
             anchor = document.createElement("a");


### PR DESCRIPTION
I screwed up the WebKit fix for Chrome/Safari. Here's a fix. Sorry about that.