### PR TITLE
iOS: Fix crash marking story as unread if no story has been displayed yet.

### DIFF
--- a/clients/ios/Classes/NewsBlurAppDelegate.m
+++ b/clients/ios/Classes/NewsBlurAppDelegate.m
@@ -1908,10 +1908,10 @@
 }
 
 - (void)finishMarkAsUnread:(NSDictionary *)story {
+    if (!storyPageControl.previousPage || !storyPageControl.currentPage || !storyPageControl.nextPage) return;
     for (StoryDetailViewController *page in @[storyPageControl.previousPage,
                                               storyPageControl.currentPage,
                                               storyPageControl.nextPage]) {
-        if (!page) continue;
         if ([[page.activeStory objectForKey:@"story_hash"]
              isEqualToString:[story objectForKey:@"story_hash"]]) {
             page.isRecentlyUnread = YES;


### PR DESCRIPTION
(NSArrays cannot contain nil; finishMarkAsRead: already did this correctly.)