### PR TITLE
iOS: Fix long-press story training from feed detail view.

### DIFF
--- a/clients/ios/Classes/FeedDetailViewController.m
+++ b/clients/ios/Classes/FeedDetailViewController.m
@@ -1733,6 +1733,7 @@ didEndSwipingSwipingWithState:(MCSwipeTableViewCellState)state
         [self.storyTitlesTable reloadRowsAtIndexPaths:@[indexPath]
                                      withRowAnimation:UITableViewRowAnimationFade];
     } else if ([longPressStoryTitle isEqualToString:@"train_story"]) {
+        appDelegate.activeStory = story;
         [appDelegate openTrainStory:cell];
     }
 }


### PR DESCRIPTION
The active story wasn't being set so this wasn't working.