### PR TITLE
Fix Mail action in "Send to" from the original story view not including the URL

### DIFF
--- a/clients/ios/Classes/NBActivityItemProvider.m
+++ b/clients/ios/Classes/NBActivityItemProvider.m
@@ -46,9 +46,10 @@
 }
 
 -(id)activityViewController:(UIActivityViewController *)activityViewController itemForActivityType:(NSString *)activityType {
-    if ([activityType isEqualToString:UIActivityTypeMail] ||
-        [activityType isEqualToString:@"com.evernote.iPhone.Evernote.EvernoteShare"]) {
-        return @{@"body": text ?: @"", @"subject": title};
+    if ([activityType isEqualToString:UIActivityTypeMail]) {
+        return text ?: (url ?: @"");
+    } else if ([activityType isEqualToString:@"com.evernote.iPhone.Evernote.EvernoteShare"]) {
+        return @{@"body": text ?: (url ?: @""), @"subject": title};
     } else if ([activityType isEqualToString:UIActivityTypePostToTwitter] ||
                [activityType isEqualToString:UIActivityTypePostToFacebook] ||
                [activityType isEqualToString:UIActivityTypePostToWeibo]) {


### PR DESCRIPTION
After 1bbb0fc7e04b90c02305335db00d3ffc7fcf0905 the original URL is no longer included as a separate activity item, so we need to include it in the mail body directly.

Mailing from the story view directly not affected, there we include the URL in the text (done by NewsBlurAppDelegate's `showSendTo:withUrl:authorName:text:title:feedTitle:images:`)