### PR TITLE
Use standard mode in the story detail web view.

### DIFF
--- a/clients/ios/Classes/StoryDetailViewController.m
+++ b/clients/ios/Classes/StoryDetailViewController.m
@@ -411,6 +411,7 @@
 
     NSString *storyHeader = [self getHeader];
     NSString *htmlString = [NSString stringWithFormat:@
+                            "<!DOCTYPE html>\n"
                             "<html>"
                             "<head>%@</head>" // header string
                             "<body id=\"story_pane\" class=\"%@ %@\">"


### PR DESCRIPTION
It missing a doc type, which was resulting in quirks mode being used. This affects font-size inheritance in tables and other rendering behavior.