### PR TITLE
Fix typo on api docs

### DIFF
--- a/templates/static/api.xhtml
+++ b/templates/static/api.xhtml
@@ -38,7 +38,7 @@
   <div class="NB-module">
     <h5 class="NB-module-title">A Note about OAuth</h5>
     <div class="NB-module-content">
-      <p>NewsBlur supports OAuth but to have an OAuth enabled clienty you must 
+      <p>NewsBlur supports OAuth but to have an OAuth enabled client you must 
           <a href="mailto:samuel@newsblur.com">email Samuel</a> to request a client ID and
           secret. You will need to provide your NewsBlur username, redirect URI (often just your
           client app's website), and app name.</p>


### PR DESCRIPTION
I noticed this while reading the docs.