### PR TITLE
iOS: Work around iOS 9 issue where training menu doesn’t appear the first time you select text.

### DIFF
--- a/clients/ios/Classes/TrainerViewController.m
+++ b/clients/ios/Classes/TrainerViewController.m
@@ -48,6 +48,10 @@
     [self hideGradientBackground:webView];
     [self.webView.scrollView setDelaysContentTouches:YES];
     [self.webView.scrollView setDecelerationRate:UIScrollViewDecelerationRateNormal];
+
+    // Work around iOS 9 issue where menu doesn't appear the first time
+    // http://stackoverflow.com/questions/32685198/
+    [self.webView becomeFirstResponder];
 }
 - (void) hideGradientBackground:(UIView*)theView
 {
@@ -612,6 +616,12 @@ shouldStartLoadWithRequest:(NSURLRequest *)request
 - (void)hideTitle:(id)sender {
     NewsBlurAppDelegate *appDelegate = [NewsBlurAppDelegate sharedAppDelegate];
     [appDelegate.trainerViewController changeTitle:sender score:-1];
+}
+
+// Work around iOS 9 issue where menu doesn't appear the first time
+// http://stackoverflow.com/questions/32685198/
+- (BOOL)canBecomeFirstResponder {
+    return YES;
 }
 
 @end


### PR DESCRIPTION
This has been bugging me for a while; thought it was a NewsBlur bug.  I can't see how this would disturb anything if/when Apple were to fix the underlying issue.

Source of the workaround and more information at http://stackoverflow.com/questions/32685198/.