### PR TITLE
Android: Fix loading of stories in bad network conditions

### DIFF
--- a/clients/android/NewsBlur/src/com/newsblur/activity/Main.java
+++ b/clients/android/NewsBlur/src/com/newsblur/activity/Main.java
@@ -100,7 +100,11 @@ public class Main extends NbActivity implements StateChangedListener, SwipeRefre
     protected void onResume() {
         super.onResume();
 
+        // immediately clear the story session to prevent bleed-over into the next
+        FeedUtils.clearStorySession();
+        // also queue a clear right before the feedset switches, so no in-flight stoires bleed
         NBSyncService.resetReadingSession();
+
         NBSyncService.flushRecounts();
 
         updateStatusIndicators();

--- a/clients/android/NewsBlur/src/com/newsblur/database/BlurDatabaseHelper.java
+++ b/clients/android/NewsBlur/src/com/newsblur/database/BlurDatabaseHelper.java
@@ -913,7 +913,7 @@ public class BlurDatabaseHelper {
         synchronized (RW_MUTEX) {dbRW.delete(DatabaseConstants.READING_SESSION_TABLE, null, null);}
     }
 
-    private void prepareReadingSession(FeedSet fs) {
+    public void prepareReadingSession(FeedSet fs) {
         ReadFilter readFilter = PrefsUtils.getReadFilter(context, fs);
         StateFilter stateFilter = PrefsUtils.getStateFilter(context);
         prepareReadingSession(fs, stateFilter, readFilter);

--- a/clients/android/NewsBlur/src/com/newsblur/util/FeedUtils.java
+++ b/clients/android/NewsBlur/src/com/newsblur/util/FeedUtils.java
@@ -49,6 +49,16 @@ public class FeedUtils {
         dbHelper.dropAndRecreateTables();
     }
 
+    public static void clearStorySession() {
+        new AsyncTask<Void, Void, Void>() {
+            @Override
+            protected Void doInBackground(Void... arg) {
+                dbHelper.clearStorySession();
+                return null;
+            }
+        }.executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR);
+    }
+
 	public static void setStorySaved(final Story story, final boolean saved, final Context context) {
         new AsyncTask<Void, Void, Void>() {
             @Override


### PR DESCRIPTION
Fixing a bug where stories (even prefetched/offline) can fail to load or may load into the wrong views when the device's network state is blackholed (not offline, but experiencing extreme timeouts).