### PR TITLE
Android: Fix On-Upgrade Crashes

### DIFF
--- a/clients/android/NewsBlur/AndroidManifest.xml
+++ b/clients/android/NewsBlur/AndroidManifest.xml
@@ -2,7 +2,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.newsblur"
     android:versionCode="125"
-    android:versionName="4.8.1b2" >
+    android:versionName="4.9.0b2" >
 
     <uses-sdk
         android:minSdkVersion="14"
@@ -24,6 +24,7 @@
         <activity
             android:name=".activity.InitActivity"
             android:label="@string/newsblur"
+            android:theme="@style/initStyle"
             android:noHistory="true">
             <intent-filter>
                 <category android:name="android.intent.category.LAUNCHER" />

--- a/clients/android/NewsBlur/res/layout/activity_init.xml
+++ b/clients/android/NewsBlur/res/layout/activity_init.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<RelativeLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent" >
+
+    <ImageView
+        android:id="@+id/init_image"
+        android:src="@drawable/logo"
+        android:layout_height="wrap_content"
+        android:layout_width="wrap_content"
+        android:layout_gravity="center"
+        android:gravity="center"
+        android:layout_centerInParent="true"
+    />
+
+</RelativeLayout>

--- a/clients/android/NewsBlur/res/values/colors.xml
+++ b/clients/android/NewsBlur/res/values/colors.xml
@@ -6,6 +6,7 @@
     <color name="midgray">#898989</color>
     <color name="lightgray">#ccc</color>
     <color name="black">#000000</color>
+    <color name="transparent">#00000000</color>
 
     <color name="folder_background_end">#E9EBE4</color>
     <color name="folder_background_start">#DDE0D7</color>

--- a/clients/android/NewsBlur/res/values/styles.xml
+++ b/clients/android/NewsBlur/res/values/styles.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:android="http://schemas.android.com/apk/res/android">
 
+    <style name="initStyle" parent="@android:style/Theme.DeviceDefault.NoActionBar">
+        <item name="android:windowBackground">@color/transparent</item>
+    </style>
+
     <style name="classifyDialog" parent="@android:style/Theme.Dialog">
         <item name="android:background">@drawable/actionbar_background</item>
         <item name="android:textColor">@color/darkgray</item>

--- a/clients/android/NewsBlur/src/com/newsblur/activity/InitActivity.java
+++ b/clients/android/NewsBlur/src/com/newsblur/activity/InitActivity.java
@@ -3,11 +3,14 @@ package com.newsblur.activity;
 import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
+import android.os.AsyncTask;
 import android.os.Bundle;
 import android.app.Activity;
 
+import com.newsblur.R;
 import com.newsblur.util.FeedUtils;
 import com.newsblur.util.PrefConstants;
+import com.newsblur.util.PrefsUtils;
 
 /**
  * The very first activity we launch. Checks to see if there is a user logged in yet and then
@@ -20,8 +23,29 @@ public class InitActivity extends Activity {
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
 
+        setContentView(R.layout.activity_init);
+        getWindow().setBackgroundDrawableResource(android.R.color.transparent);
+        getActionBar().hide();
+
+        // do actual app launch after just a moment so the init screen smoothly loads
+        new AsyncTask<Void, Void, Void>() {
+            @Override
+            protected Void doInBackground(Void... arg) {
+                start();
+                return null;
+            }
+        }.execute();
+
+    }
+
+    private void start() {
         // this is the first Activity launched; use it to init the global singletons in FeedUtils
         FeedUtils.offerInitContext(this);
+
+        // now before there is any chance at all of an activity hitting the DB and crashing when it
+        // cannot find new tables or columns right after an app upgrade, check to see if the DB
+        // needs an upgrade
+        upgradeCheck();
 
         // see if a user is already logged in; if so, jump to the Main activity
         preferenceCheck();
@@ -35,6 +59,14 @@ public class InitActivity extends Activity {
         } else {
             Intent loginIntent = new Intent(this, Login.class);
             startActivity(loginIntent);
+        }
+    }
+
+    private void upgradeCheck() {
+        boolean upgrade = PrefsUtils.checkForUpgrade(this);
+        if (upgrade) {
+            FeedUtils.dbHelper.dropAndRecreateTables();
+            PrefsUtils.updateVersion(this);
         }
     }
 

--- a/clients/android/NewsBlur/src/com/newsblur/activity/InitActivity.java
+++ b/clients/android/NewsBlur/src/com/newsblur/activity/InitActivity.java
@@ -24,8 +24,6 @@ public class InitActivity extends Activity {
         super.onCreate(savedInstanceState);
 
         setContentView(R.layout.activity_init);
-        getWindow().setBackgroundDrawableResource(android.R.color.transparent);
-        getActionBar().hide();
 
         // do actual app launch after just a moment so the init screen smoothly loads
         new AsyncTask<Void, Void, Void>() {

--- a/clients/android/NewsBlur/src/com/newsblur/util/AppConstants.java
+++ b/clients/android/NewsBlur/src/com/newsblur/util/AppConstants.java
@@ -7,7 +7,7 @@ public class AppConstants {
     // Enables high-volume logging that may be useful for debugging. This should
     // never be enabled for releases, as it not only slows down the app considerably,
     // it will log sensitive info such as passwords!
-    public static final boolean VERBOSE_LOG = true;
+    public static final boolean VERBOSE_LOG = false;
     public static final boolean VERBOSE_LOG_DB = false;
     public static final boolean VERBOSE_LOG_NET = false;
 	


### PR DESCRIPTION
Finally gave in and implemented some more strict on-upgrade checking.  Newer devices were launching the UI so quickly, sometimes the app would crash because the UI was trying to access the DB before it was upgraded.

There is now a splash screen when the app is opened the first time after install or upgrade while the check is occuring.  Total time from app start to the UI being displayed in full has actually stayed the same or gone down (time in the spash is == the time the UI used to pause with the "Tidying up" message), though being forced to use a spash might make it appear a bit slower due to some unfortunate cognitive biases.  Can't think of any more reliable way to finally squash the on-upgrade crashes, though.

Also disabled debug logging, since I expect this will be our final release candidate if all goes smoothly.