### PR TITLE
Switch to filter instead of opacity

### DIFF
--- a/media/css/reader.css
+++ b/media/css/reader.css
@@ -423,7 +423,7 @@ a img {
   background: transparent url("/media/embed/reader/big_world.png") no-repeat center 0;
   background-size: 64px;
   color: rgba(0, 0, 0, .4);
-  opacity: .4;
+  filter: opacity(0.4);
   font-size: 16px;
   padding: 78px 16px 0;
   margin: 48px 0;
@@ -441,7 +441,7 @@ a img {
 }
 .NB-story-list-empty {
   color: rgba(0, 0, 0, .4);
-  opacity: .4;
+  filter: opacity(0.4);
   font-size: 16px;
   padding: 256px 24px;
   text-shadow: 0 1px 0 rgba(255, 255, 255, .4);


### PR DESCRIPTION
In Firefox, opacity causes the background color underneath the container to pop through. By using filter instead, only the elements on top of background are affected.

In Chrome, they both have the same effect.