### PR TITLE
fix weird old activity title casing issue found in #938

### DIFF
--- a/clients/android/NewsBlur/src/com/newsblur/activity/AllStoriesItemsList.java
+++ b/clients/android/NewsBlur/src/com/newsblur/activity/AllStoriesItemsList.java
@@ -19,7 +19,7 @@ public class AllStoriesItemsList extends ItemsList {
 	protected void onCreate(Bundle bundle) {
 		super.onCreate(bundle);
 
-        UIUtils.setCustomActionBar(this, R.drawable.ak_icon_allstories, getResources().getString(R.string.all_stories));
+        UIUtils.setCustomActionBar(this, R.drawable.ak_icon_allstories, getResources().getString(R.string.all_stories_row_title));
 
 		itemListFragment = (AllStoriesItemListFragment) fragmentManager.findFragmentByTag(AllStoriesItemListFragment.class.getName());
 		if (itemListFragment == null) {


### PR DESCRIPTION
Fixed the place spotted in #938 where we have been using a totally wrong string asset. 