### PR TITLE
Android automatic refactor - Recycle

### DIFF
--- a/clients/android/NewsBlur/src/com/newsblur/database/BlurDatabaseHelper.java
+++ b/clients/android/NewsBlur/src/com/newsblur/database/BlurDatabaseHelper.java
@@ -493,10 +493,16 @@ public class BlurDatabaseHelper {
         Cursor c = dbRO.query(DatabaseConstants.FOLDER_TABLE, null, selection, selArgs, null, null, null);
         if (c.getCount() < 1) {
             closeQuietly(c);
-            return null;
+            if (c != null) {
+				c.close();
+			}
+			return null;
         }
         Folder folder = Folder.fromCursor(c);
         closeQuietly(c);
+		if (c != null) {
+			c.close();
+		}
         return folder;
     }
 


### PR DESCRIPTION
Hi,

I am developing a tool to automatically refactor Android applications with the goal of improving energy efficiency.
This pull request has the changes generated while applying the rule "Recycle".

Some resources (e.g., ```Cursor``` instances) should be closed when they are no longer necessary. 

I have made a previous validation of the changes and they seem correct.
Please consider them and let me know if you agree with them.

Best,
Luis
