### PR TITLE
Add Firefox to story browser list

### DIFF
--- a/clients/ios/Classes/NewsBlurAppDelegate.m
+++ b/clients/ios/Classes/NewsBlurAppDelegate.m
@@ -1633,10 +1633,11 @@
 - (void)showOriginalStory:(NSURL *)url {
     NSUserDefaults *preferences = [NSUserDefaults standardUserDefaults];
     
-    if ([[preferences stringForKey:@"story_browser"] isEqualToString:@"safari"]) {
+    NSString *storyBrowser = [preferences stringForKey:@"story_browser"];
+    if ([storyBrowser isEqualToString:@"safari"]) {
         [[UIApplication sharedApplication] openURL:url];
         return;
-    } else if ([[preferences stringForKey:@"story_browser"] isEqualToString:@"chrome"] &&
+    } else if ([storyBrowser isEqualToString:@"chrome"] &&
                [[UIApplication sharedApplication] canOpenURL:[NSURL URLWithString:@"googlechrome-x-callback://"]]) {
         NSString *openingURL = [url.absoluteString stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding];
         NSURL *callbackURL = [NSURL URLWithString:@"newsblur://"];
@@ -1651,7 +1652,7 @@
         
         [[UIApplication sharedApplication] openURL:activityURL];
         return;
-    } else if ([[preferences stringForKey:@"story_browser"] isEqualToString:@"opera_mini"] &&
+    } else if ([storyBrowser isEqualToString:@"opera_mini"] &&
                [[UIApplication sharedApplication] canOpenURL:[NSURL URLWithString:@"opera-http://"]]) {
 
                    
@@ -1665,7 +1666,11 @@
                    
         [[UIApplication sharedApplication] openURL:[NSURL URLWithString:operaURL]];
         return;
-    } else if ([[preferences stringForKey:@"story_browser"] isEqualToString:@"inappsafari"]) {
+    } else if ([storyBrowser isEqualToString:@"firefox"]) {
+        NSString *encodedURL = [url.absoluteString stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLHostAllowedCharacterSet]];
+        NSString *firefoxURL = [NSString stringWithFormat:@"%@%@", @"firefox://?url=", encodedURL];
+        [[UIApplication sharedApplication] openURL:[NSURL URLWithString:firefoxURL]];
+    } else if ([storyBrowser isEqualToString:@"inappsafari"]) {
         self.safariViewController = [[SFSafariViewController alloc] initWithURL:url
                                                         entersReaderIfAvailable:NO];
         self.safariViewController.delegate = self;

--- a/clients/ios/Resources/Settings.bundle/Root.plist
+++ b/clients/ios/Resources/Settings.bundle/Root.plist
@@ -592,6 +592,7 @@
 				<string>Safari</string>
 				<string>Chrome</string>
 				<string>Opera Mini</string>
+				<string>Firefox</string>
 			</array>
 			<key>DefaultValue</key>
 			<string>inapp</string>
@@ -602,6 +603,7 @@
 				<string>safari</string>
 				<string>chrome</string>
 				<string>opera_mini</string>
+				<string>firefox</string>
 			</array>
 			<key>Key</key>
 			<string>story_browser</string>

--- a/clients/ios/Resources/Settings.bundle/Root~ipad.plist
+++ b/clients/ios/Resources/Settings.bundle/Root~ipad.plist
@@ -612,6 +612,7 @@
 				<string>Safari</string>
 				<string>Chrome</string>
 				<string>Opera Mini</string>
+				<string>Firefox</string>
 			</array>
 			<key>DefaultValue</key>
 			<string>inapp</string>
@@ -622,6 +623,7 @@
 				<string>safari</string>
 				<string>chrome</string>
 				<string>opera_mini</string>
+				<string>firefox</string>
 			</array>
 			<key>Key</key>
 			<string>story_browser</string>


### PR DESCRIPTION
This can be tested by:

1. Installing Firefox iOS app on simulator https://github.com/mozilla-mobile/firefox-ios
2. Installing this PR on simulator
3. Running NewsBlur
4. In app preferences change story browser to Firefox
5. Go to story detail screen and tap on browser icon