### PR TITLE
Fix for Site titles in Edge

### DIFF
--- a/media/css/reader.css
+++ b/media/css/reader.css
@@ -691,6 +691,7 @@ a img {
     -webkit-line-clamp: 1;
     -webkit-box-orient: vertical;
     display: -webkit-box;
+    white-space: nowrap;
 }
 
 .NB-feedlist .feed .NB-feedlist-manage-icon,


### PR DESCRIPTION
Fix so that titles are truncated with an ellipsis in Edge browser. https://github.com/samuelclay/NewsBlur/issues/1030

Before:
![image](https://user-images.githubusercontent.com/2324109/28493546-943249a0-6f10-11e7-8ebd-30f9a3991d77.png)

After:
![image](https://user-images.githubusercontent.com/2324109/28493547-9e223574-6f10-11e7-8542-89c79ba87598.png)



