### PR TITLE
Android: Social Fixes, Insta-Fetch, Bugfixes

### DIFF
--- a/clients/android/NewsBlur/AndroidManifest.xml
+++ b/clients/android/NewsBlur/AndroidManifest.xml
@@ -2,7 +2,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.newsblur"
     android:versionCode="141"
-    android:versionName="6.0.0" >
+    android:versionName="6.0.2" >
 
     <uses-sdk
         android:minSdkVersion="19"

--- a/clients/android/NewsBlur/res/layout/row_feed.xml
+++ b/clients/android/NewsBlur/res/layout/row_feed.xml
@@ -72,6 +72,14 @@
             style="?muteicon"
             android:background="@drawable/neutral_count_rect"/>
 
+        <ProgressBar
+            android:id="@+id/row_feedfetching"
+            android:layout_width="21dp"
+            android:layout_height="21dp"
+            android:layout_marginRight="3dp"
+            android:visibility="gone"
+            android:indeterminate="true" />
+
     </LinearLayout>
 
     <ImageView

--- a/clients/android/NewsBlur/res/menu/context_feed.xml
+++ b/clients/android/NewsBlur/res/menu/context_feed.xml
@@ -35,4 +35,7 @@
 
     <item android:id="@+id/menu_unmute_feed"
           android:title="@string/menu_unmute_feed" />
+
+    <item android:id="@+id/menu_instafetch_feed"
+          android:title="@string/menu_instafetch_feed" />
 </menu>

--- a/clients/android/NewsBlur/res/menu/feed_itemslist.xml
+++ b/clients/android/NewsBlur/res/menu/feed_itemslist.xml
@@ -34,6 +34,8 @@
             </group>
         </menu>
     </item>
+    <item android:id="@+id/menu_instafetch_feed"
+          android:title="@string/menu_instafetch_feed" />
     <item android:id="@+id/menu_search_stories"
           android:title="@string/menu_search_stories"
           android:showAsAction="ifRoom" android:icon="@drawable/ic_menu_search_gray55" />

--- a/clients/android/NewsBlur/res/values/strings.xml
+++ b/clients/android/NewsBlur/res/values/strings.xml
@@ -66,6 +66,7 @@
     <string name="overlay_count_toast_1">1 unread story</string>
     <string name="overlay_text">TEXT</string>
     <string name="overlay_story">STORY</string>
+    <string name="text_mode_unavailable">Sorry, the story\'s text could not be extracted.</string>
 
     <string name="state_all">ALL</string>
     <string name="state_unread">UNREAD</string>

--- a/clients/android/NewsBlur/res/values/strings.xml
+++ b/clients/android/NewsBlur/res/values/strings.xml
@@ -146,6 +146,7 @@
     <string name="menu_unmute_feed">Unmute feed</string>
     <string name="menu_mute_folder">Mute folder</string>
     <string name="menu_unmute_folder">Unmute folder</string>
+    <string name="menu_instafetch_feed">Insta-fetch stories</string>
     
     <string name="toast_story_unread">Story marked as unread</string>
 

--- a/clients/android/NewsBlur/res/values/strings.xml
+++ b/clients/android/NewsBlur/res/values/strings.xml
@@ -54,7 +54,8 @@
     <string name="share_this">SHARE</string>
     <string name="already_shared">SHARED</string>
     <string name="share_this_story">SHARE</string>
-    <string name="update_shared">Update comment</string>
+    <string name="unshare">DELETE SHARE</string>
+    <string name="update_shared">UPDATE COMMENT</string>
 
 	<string name="save_this">SAVE</string>
 	<string name="unsave_this">REMOVE FROM SAVED</string>

--- a/clients/android/NewsBlur/src/com/newsblur/activity/FeedItemsList.java
+++ b/clients/android/NewsBlur/src/com/newsblur/activity/FeedItemsList.java
@@ -68,6 +68,11 @@ public class FeedItemsList extends ItemsList {
             FeedUtils.enableUnreadNotifications(this, feed);
             return true;
         }
+        if (item.getItemId() == R.id.menu_instafetch_feed) {
+            FeedUtils.instaFetchFeed(this, feed.feedId);
+            this.finish();
+            return true;
+        }
         return false;
 	}
 	

--- a/clients/android/NewsBlur/src/com/newsblur/activity/ReadingAdapter.java
+++ b/clients/android/NewsBlur/src/com/newsblur/activity/ReadingAdapter.java
@@ -4,7 +4,6 @@ import android.database.Cursor;
 import android.app.Fragment;
 import android.app.FragmentManager;
 import android.support.v13.app.FragmentStatePagerAdapter;
-import android.util.Log;
 import android.util.SparseArray;
 import android.view.ViewGroup;
 

--- a/clients/android/NewsBlur/src/com/newsblur/database/BlurDatabaseHelper.java
+++ b/clients/android/NewsBlur/src/com/newsblur/database/BlurDatabaseHelper.java
@@ -450,6 +450,15 @@ public class BlurDatabaseHelper {
             // comments often contain enclosed replies, so batch them.
             dbRW.beginTransaction();
             try {
+                // the API might include new supplemental user metadata if new replies have shown up.
+                if (apiResponse.users != null) {
+                    List<ContentValues> userValues = new ArrayList<ContentValues>(apiResponse.users.length);
+                    for (UserProfile user : apiResponse.users) {
+                        userValues.add(user.getValues());
+                    }
+                    bulkInsertValuesExtSync(DatabaseConstants.USER_TABLE, userValues);
+                }
+
                 // we store all comments in the context of the associated story, but the social API doesn't
                 // reference the story when responding, so fix that from our context
                 apiResponse.comment.storyId = storyId;

--- a/clients/android/NewsBlur/src/com/newsblur/database/BlurDatabaseHelper.java
+++ b/clients/android/NewsBlur/src/com/newsblur/database/BlurDatabaseHelper.java
@@ -557,6 +557,29 @@ public class BlurDatabaseHelper {
         }
     }
 
+    public void setFeedFetchPending(String feedId) {
+        ContentValues values = new ContentValues();
+        values.put(DatabaseConstants.FEED_FETCH_PENDING, true);
+        synchronized (RW_MUTEX) {dbRW.update(DatabaseConstants.FEED_TABLE, values, DatabaseConstants.FEED_ID + " = ?", new String[]{feedId});}
+    }
+
+    public boolean isFeedSetFetchPending(FeedSet fs) {
+        if (fs.getSingleFeed() != null) {
+            String feedId = fs.getSingleFeed();
+            Cursor c = dbRO.query(DatabaseConstants.FEED_TABLE, 
+                                  new String[]{DatabaseConstants.FEED_FETCH_PENDING}, 
+                                  DatabaseConstants.FEED_ID + " = ? AND " + DatabaseConstants.FEED_FETCH_PENDING + " = ?", 
+                                  new String[]{feedId, "1"}, 
+                                  null, null, null);
+            try {
+                if (c.getCount() > 0) return true;
+            } finally {
+                closeQuietly(c);
+            }
+        }
+        return false;
+    }
+
     /**
      * Marks a story (un)read but does not adjust counts. Must stay idempotent an time-insensitive.
      */

--- a/clients/android/NewsBlur/src/com/newsblur/database/BlurDatabaseHelper.java
+++ b/clients/android/NewsBlur/src/com/newsblur/database/BlurDatabaseHelper.java
@@ -1219,29 +1219,27 @@ public class BlurDatabaseHelper {
                                              new String[]{storyId, userId});}
     }
 
-    /* TODO: we cannot locally like comments without their proper ID
     public void setCommentLiked(String storyId, String userId, String feedId, boolean liked) {
-        String commentKey = Comment.constructId(storyId, feedId, userId);
         // get a fresh copy of the story from the DB so we can append to the shared ID set
         Cursor c = dbRO.query(DatabaseConstants.COMMENT_TABLE, 
-                              new String[]{DatabaseConstants.COMMENT_LIKING_USERS}, 
-                              DatabaseConstants.COMMENT_ID + " = ?", 
-                              new String[]{commentKey}, 
+                              null, 
+                              DatabaseConstants.COMMENT_STORYID + " = ? AND " + DatabaseConstants.COMMENT_USERID + " = ?", 
+                              new String[]{storyId, userId}, 
                               null, null, null);
         if ((c == null)||(c.getCount() < 1)) {
-            Log.w(this.getClass().getName(), "story removed before finishing mark-shared");
+            Log.w(this.getClass().getName(), "comment removed before finishing mark-liked");
             closeQuietly(c);
             return;
         }
         c.moveToFirst();
-		String[] likingUserIds = TextUtils.split(c.getString(c.getColumnIndex(DatabaseConstants.COMMENT_LIKING_USERS)), ",");
+        Comment comment = Comment.fromCursor(c);
         closeQuietly(c);
 
         // the new id to append/remove from the liking list (the current user)
         String currentUser = PrefsUtils.getUserDetails(context).id;
 
         // append to set and update DB
-        Set<String> newIds = new HashSet<String>(Arrays.asList(likingUserIds));
+        Set<String> newIds = new HashSet<String>(Arrays.asList(comment.likingUsers));
         if (liked) {
             newIds.add(currentUser);
         } else {
@@ -1249,9 +1247,8 @@ public class BlurDatabaseHelper {
         }
         ContentValues values = new ContentValues();
 		values.put(DatabaseConstants.COMMENT_LIKING_USERS, TextUtils.join(",", newIds));
-        synchronized (RW_MUTEX) {dbRW.update(DatabaseConstants.COMMENT_TABLE, values, DatabaseConstants.COMMENT_ID + " = ?", new String[]{commentKey});}
+        synchronized (RW_MUTEX) {dbRW.update(DatabaseConstants.COMMENT_TABLE, values, DatabaseConstants.COMMENT_ID + " = ?", new String[]{comment.id});}
     }
-    */
 
     public UserProfile getUserProfile(String userId) {
         String[] selArgs = new String[] {userId};

--- a/clients/android/NewsBlur/src/com/newsblur/database/BlurDatabaseHelper.java
+++ b/clients/android/NewsBlur/src/com/newsblur/database/BlurDatabaseHelper.java
@@ -1233,6 +1233,16 @@ public class BlurDatabaseHelper {
         }
     }
 
+    public void editReply(String replyId, String replyText) {
+        ContentValues values = new ContentValues();
+        values.put(DatabaseConstants.REPLY_TEXT, replyText);
+        synchronized (RW_MUTEX) {dbRW.update(DatabaseConstants.REPLY_TABLE, values, DatabaseConstants.REPLY_ID + " = ?", new String[]{replyId});}
+    }
+
+    public void deleteReply(String replyId) {   
+        synchronized (RW_MUTEX) {dbRW.delete(DatabaseConstants.REPLY_TABLE, DatabaseConstants.REPLY_ID + " = ?", new String[]{replyId});}
+    }
+
     public void clearSelfComments(String storyId) {
         String userId = PrefsUtils.getUserDetails(context).id;
         synchronized (RW_MUTEX) {dbRW.delete(DatabaseConstants.COMMENT_TABLE, 

--- a/clients/android/NewsBlur/src/com/newsblur/database/DatabaseConstants.java
+++ b/clients/android/NewsBlur/src/com/newsblur/database/DatabaseConstants.java
@@ -127,6 +127,7 @@ public class DatabaseConstants {
 	public static final String REPLY_USERID = "reply_userid";
 	public static final String REPLY_DATE = "reply_date";
 	public static final String REPLY_SHORTDATE = "reply_shortdate";
+	public static final String REPLY_ISPLACEHOLDER = "reply_isplaceholder";
 
     public static final String ACTION_TABLE = "story_actions";
 	public static final String ACTION_ID = BaseColumns._ID;
@@ -220,7 +221,8 @@ public class DatabaseConstants {
 		REPLY_ID + TEXT + " PRIMARY KEY, " +
 		REPLY_COMMENTID + TEXT + ", " + 
 		REPLY_TEXT + TEXT + ", " +
-		REPLY_USERID + TEXT +
+		REPLY_USERID + TEXT + ", " +
+        REPLY_ISPLACEHOLDER + TEXT +
 		")";
 	
 	static final String STORY_SQL = "CREATE TABLE " + STORY_TABLE + " (" + 

--- a/clients/android/NewsBlur/src/com/newsblur/database/DatabaseConstants.java
+++ b/clients/android/NewsBlur/src/com/newsblur/database/DatabaseConstants.java
@@ -118,6 +118,7 @@ public class DatabaseConstants {
 	public static final String COMMENT_BYFRIEND = "comment_byfriend";
 	public static final String COMMENT_USERID = "comment_userid";
 	public static final String COMMENT_ISPSEUDO = "comment_ispseudo";
+	public static final String COMMENT_ISPLACEHOLDER = "comment_isplaceholder";
 
 	public static final String REPLY_TABLE = "comment_replies";
 	public static final String REPLY_ID = BaseColumns._ID;
@@ -209,7 +210,8 @@ public class DatabaseConstants {
 		COMMENT_STORYID + TEXT + ", " + 
 		COMMENT_TEXT + TEXT + ", " +
 		COMMENT_USERID + TEXT + ", " +
-        COMMENT_ISPSEUDO + TEXT +
+        COMMENT_ISPSEUDO + TEXT + ", " +
+        COMMENT_ISPLACEHOLDER + TEXT +
 		")";
 	
 	static final String REPLY_SQL = "CREATE TABLE " + REPLY_TABLE + " (" +

--- a/clients/android/NewsBlur/src/com/newsblur/database/DatabaseConstants.java
+++ b/clients/android/NewsBlur/src/com/newsblur/database/DatabaseConstants.java
@@ -44,6 +44,7 @@ public class DatabaseConstants {
 	public static final String FEED_NEGATIVE_COUNT = "ng";
     public static final String FEED_NOTIFICATION_TYPES = "notification_types";
     public static final String FEED_NOTIFICATION_FILTER = "notification_filter";
+    public static final String FEED_FETCH_PENDING = "fetch_pending";
 
 	public static final String SOCIALFEED_TABLE = "social_feeds";
 	public static final String SOCIAL_FEED_ID = BaseColumns._ID;
@@ -181,7 +182,8 @@ public class DatabaseConstants {
 		FEED_TITLE + TEXT + ", " + 
 		FEED_UPDATED_SECONDS + INTEGER + ", " +
         FEED_NOTIFICATION_TYPES + TEXT + ", " +
-        FEED_NOTIFICATION_FILTER + TEXT +
+        FEED_NOTIFICATION_FILTER + TEXT + ", " +
+        FEED_FETCH_PENDING + TEXT +
 		")";
 	
 	static final String USER_SQL = "CREATE TABLE " + USER_TABLE + " (" + 

--- a/clients/android/NewsBlur/src/com/newsblur/database/FolderListAdapter.java
+++ b/clients/android/NewsBlur/src/com/newsblur/database/FolderListAdapter.java
@@ -21,6 +21,7 @@ import android.view.ViewGroup;
 import android.widget.BaseExpandableListAdapter;
 import android.widget.ExpandableListView;
 import android.widget.ImageView;
+import android.widget.ProgressBar;
 import android.widget.TextView;
 
 import com.newsblur.R;
@@ -252,23 +253,37 @@ public class FolderListAdapter extends BaseExpandableListAdapter {
             TextView posCounter = ((TextView) v.findViewById(R.id.row_feedpositive));
             TextView savedCounter = ((TextView) v.findViewById(R.id.row_feedsaved));
             ImageView muteIcon = ((ImageView) v.findViewById(R.id.row_feedmuteicon));
+            ProgressBar fetchingIcon = ((ProgressBar) v.findViewById(R.id.row_feedfetching));
             if (!f.active) {
                 muteIcon.setVisibility(View.VISIBLE);
                 neutCounter.setVisibility(View.GONE);
                 posCounter.setVisibility(View.GONE);
                 savedCounter.setVisibility(View.GONE);
+                fetchingIcon.setVisibility(View.GONE);
+                fetchingIcon.setProgress(100);
+            } else if (f.fetchPending) {
+                muteIcon.setVisibility(View.GONE);
+                neutCounter.setVisibility(View.GONE);
+                posCounter.setVisibility(View.GONE);
+                savedCounter.setVisibility(View.GONE);
+                fetchingIcon.setVisibility(View.VISIBLE);
+                fetchingIcon.setProgress(0);
             } else if (currentState == StateFilter.SAVED) {
                 muteIcon.setVisibility(View.GONE);
                 neutCounter.setVisibility(View.GONE);
                 posCounter.setVisibility(View.GONE);
                 savedCounter.setVisibility(View.VISIBLE);
                 savedCounter.setText(Integer.toString(zeroForNull(feedSavedCounts.get(f.feedId))));
+                fetchingIcon.setVisibility(View.GONE);
+                fetchingIcon.setProgress(100);
             } else if (currentState == StateFilter.BEST) {
                 muteIcon.setVisibility(View.GONE);
                 neutCounter.setVisibility(View.GONE);
                 savedCounter.setVisibility(View.GONE);
                 posCounter.setVisibility(View.VISIBLE);
                 posCounter.setText(Integer.toString(checkNegativeUnreads(f.positiveCount)));
+                fetchingIcon.setVisibility(View.GONE);
+                fetchingIcon.setProgress(100);
             } else {
                 muteIcon.setVisibility(View.GONE);
                 savedCounter.setVisibility(View.GONE);
@@ -284,6 +299,8 @@ public class FolderListAdapter extends BaseExpandableListAdapter {
                 } else {
                     posCounter.setVisibility(View.GONE);
                 }
+                fetchingIcon.setVisibility(View.GONE);
+                fetchingIcon.setProgress(100);
             }
             neutCounter.setTextSize(textSize * defaultTextSize_count);
             posCounter.setTextSize(textSize * defaultTextSize_count);

--- a/clients/android/NewsBlur/src/com/newsblur/database/FolderListAdapter.java
+++ b/clients/android/NewsBlur/src/com/newsblur/database/FolderListAdapter.java
@@ -559,7 +559,11 @@ public class FolderListAdapter extends BaseExpandableListAdapter {
         if (activeFolderChildren == null) return;
         int newFeedCount = 0;
         newFeedCount += socialFeedsOrdered.size();
-        newFeedCount += starredCountsByTag.size();
+        if (currentState == StateFilter.SAVED) {
+            // only count saved feeds if in saved mode, since the expectation is that we are
+            // counting to detect a zero-feeds-in-this-mode situation
+            newFeedCount += starredCountsByTag.size();
+        }
         for (List<Feed> folder : activeFolderChildren) {
             newFeedCount += folder.size();
         }

--- a/clients/android/NewsBlur/src/com/newsblur/domain/Comment.java
+++ b/clients/android/NewsBlur/src/com/newsblur/domain/Comment.java
@@ -10,6 +10,10 @@ import com.google.gson.annotations.SerializedName;
 import com.newsblur.database.DatabaseConstants;
 
 public class Comment implements Serializable {
+    
+    // new comments cannot possibly have the server-generated ID, so are inserted with partial info until reconciled
+    public static final String PLACEHOLDER_COMMENT_ID = "__PLACEHOLDER_ID__";
+
 	private static final long serialVersionUID = -2018705258520565390L;
 
 	@SerializedName("id")
@@ -35,6 +39,7 @@ public class Comment implements Serializable {
 	
 	public Reply[] replies;
 	
+    // not vended by API directly, but comments always appear in the context of a story
 	public String storyId;
 	
     // not vended by API, but we set it depending on which comment block of the response in which it appeared
@@ -42,6 +47,9 @@ public class Comment implements Serializable {
 
     // means this "comment" is actually a text-less share, which is identical to a comment, but included in a different list in the story member
     public boolean isPseudo = false;
+
+    // not vended by API, indicates this is a client-side placeholder for until we can get an ID from the server
+    public boolean isPlaceholder = false;
 
 	public ContentValues getValues() {
 		ContentValues values = new ContentValues();
@@ -55,6 +63,7 @@ public class Comment implements Serializable {
 		values.put(DatabaseConstants.COMMENT_USERID, userId);
 		values.put(DatabaseConstants.COMMENT_ID, id);
 		values.put(DatabaseConstants.COMMENT_ISPSEUDO, isPseudo ? "true" : "false");
+		values.put(DatabaseConstants.COMMENT_ISPLACEHOLDER, isPlaceholder ? "true" : "false");
 		return values;
 	}
 
@@ -71,6 +80,7 @@ public class Comment implements Serializable {
 		comment.sourceUserId = cursor.getString(cursor.getColumnIndex(DatabaseConstants.COMMENT_SOURCE_USERID));
 		comment.id = cursor.getString(cursor.getColumnIndex(DatabaseConstants.COMMENT_ID));
 		comment.isPseudo = Boolean.parseBoolean(cursor.getString(cursor.getColumnIndex(DatabaseConstants.COMMENT_ISPSEUDO)));
+		comment.isPlaceholder = Boolean.parseBoolean(cursor.getString(cursor.getColumnIndex(DatabaseConstants.COMMENT_ISPLACEHOLDER)));
 		return comment;
 	}
 

--- a/clients/android/NewsBlur/src/com/newsblur/domain/Feed.java
+++ b/clients/android/NewsBlur/src/com/newsblur/domain/Feed.java
@@ -67,6 +67,9 @@ public class Feed implements Comparable<Feed>, Serializable {
     @SerializedName("notification_filter")
     public String notificationFilter;
 
+    // not vended by API, but used locally for UI
+    public boolean fetchPending;
+
 	public ContentValues getValues() {
 		ContentValues values = new ContentValues();
 		values.put(DatabaseConstants.FEED_ID, feedId);
@@ -88,6 +91,7 @@ public class Feed implements Comparable<Feed>, Serializable {
         if (isNotifyAndroid()) {
             values.put(DatabaseConstants.FEED_NOTIFICATION_FILTER, notificationFilter);
         }
+        values.put(DatabaseConstants.FEED_FETCH_PENDING, fetchPending);
 		return values;
 	}
 
@@ -113,6 +117,7 @@ public class Feed implements Comparable<Feed>, Serializable {
         feed.lastUpdated = cursor.getInt(cursor.getColumnIndex(DatabaseConstants.FEED_UPDATED_SECONDS));
         feed.notificationTypes = DatabaseConstants.unflattenStringList(cursor.getString(cursor.getColumnIndex(DatabaseConstants.FEED_NOTIFICATION_TYPES)));
         feed.notificationFilter = cursor.getString(cursor.getColumnIndex(DatabaseConstants.FEED_NOTIFICATION_FILTER));
+        feed.fetchPending = cursor.getString(cursor.getColumnIndex(DatabaseConstants.FEED_FETCH_PENDING)).equals("1");
 		return feed;
 	}
 

--- a/clients/android/NewsBlur/src/com/newsblur/domain/Reply.java
+++ b/clients/android/NewsBlur/src/com/newsblur/domain/Reply.java
@@ -10,6 +10,10 @@ import com.google.gson.annotations.SerializedName;
 import com.newsblur.database.DatabaseConstants;
 
 public class Reply {
+
+    // new replies cannot possibly have the server-generated ID, so are inserted with partial info until reconciled
+    public static final String PLACEHOLDER_COMMENT_ID = "__PLACEHOLDER_ID__";
+
 	@SerializedName("reply_id")
 	public String id;
 
@@ -25,8 +29,11 @@ public class Reply {
 	@SerializedName("date")
 	public Date date;
 
-    // NB: this is the commentId that we generate, not the API one
+    // not vended by API directly, but all replies come in the context of an enclosing comment
 	public String commentId;
+
+    // not vended by API, indicates this is a client-side placeholder for until we can get an ID from the server
+    public boolean isPlaceholder = false;
 
 	public ContentValues getValues() {
 		ContentValues values = new ContentValues();
@@ -36,6 +43,7 @@ public class Reply {
 		values.put(DatabaseConstants.REPLY_COMMENTID, commentId);
 		values.put(DatabaseConstants.REPLY_ID, id);
 		values.put(DatabaseConstants.REPLY_USERID, userId);
+		values.put(DatabaseConstants.REPLY_ISPLACEHOLDER, isPlaceholder ? "true" : "false");
 		return values;	
 	}
 
@@ -47,6 +55,7 @@ public class Reply {
 		reply.commentId = cursor.getString(cursor.getColumnIndex(DatabaseConstants.REPLY_COMMENTID));
 		reply.id = cursor.getString(cursor.getColumnIndex(DatabaseConstants.REPLY_ID));
 		reply.userId = cursor.getString(cursor.getColumnIndex(DatabaseConstants.REPLY_USERID));
+		reply.isPlaceholder = Boolean.parseBoolean(cursor.getString(cursor.getColumnIndex(DatabaseConstants.REPLY_ISPLACEHOLDER)));
 		return reply;	
 	}
 

--- a/clients/android/NewsBlur/src/com/newsblur/fragment/FolderListFragment.java
+++ b/clients/android/NewsBlur/src/com/newsblur/fragment/FolderListFragment.java
@@ -154,6 +154,7 @@ public class FolderListFragment extends NbFragment implements OnCreateContextMen
 
 	public void hasUpdated() {
         if (isAdded()) {
+            com.newsblur.util.Log.d(this, "loading feeds in mode: " + currentState);
             try {
                 getLoaderManager().restartLoader(SOCIALFEEDS_LOADER, null, this);
                 getLoaderManager().restartLoader(FOLDERS_LOADER, null, this);

--- a/clients/android/NewsBlur/src/com/newsblur/fragment/FolderListFragment.java
+++ b/clients/android/NewsBlur/src/com/newsblur/fragment/FolderListFragment.java
@@ -262,6 +262,7 @@ public class FolderListFragment extends NbFragment implements OnCreateContextMen
                 menu.removeItem(R.id.menu_unmute_feed);
                 menu.removeItem(R.id.menu_mute_feed);
                 menu.removeItem(R.id.menu_notifications);
+                menu.removeItem(R.id.menu_instafetch_feed);
             } else {
                 menu.removeItem(R.id.menu_unfollow);
 
@@ -349,6 +350,8 @@ public class FolderListFragment extends NbFragment implements OnCreateContextMen
             FeedUtils.muteFeeds(getActivity(), adapter.getAllFeedsForFolder(groupPosition));
         } else if (item.getItemId() == R.id.menu_unmute_folder) {
             FeedUtils.unmuteFeeds(getActivity(), adapter.getAllFeedsForFolder(groupPosition));
+        } else if (item.getItemId() == R.id.menu_instafetch_feed) {
+            FeedUtils.instaFetchFeed(getActivity(), adapter.getFeed(groupPosition, childPosition).feedId);
         }
 
 		return super.onContextItemSelected(item);

--- a/clients/android/NewsBlur/src/com/newsblur/fragment/LoginProgressFragment.java
+++ b/clients/android/NewsBlur/src/com/newsblur/fragment/LoginProgressFragment.java
@@ -1,5 +1,6 @@
 package com.newsblur.fragment;
 
+import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
 import android.os.AsyncTask;
@@ -87,7 +88,7 @@ public class LoginProgressFragment extends Fragment {
 
 		@Override
 		protected void onPostExecute(LoginResponse result) {
-            Context c = getActivity();
+            Activity c = getActivity();
             if (c == null) return; // we might have run past the lifecycle of the activity
 			if (!result.isError()) {
 				final Animation a = AnimationUtils.loadAnimation(c, R.anim.text_down);

--- a/clients/android/NewsBlur/src/com/newsblur/fragment/ReadingItemFragment.java
+++ b/clients/android/NewsBlur/src/com/newsblur/fragment/ReadingItemFragment.java
@@ -28,6 +28,7 @@ import android.webkit.WebView.HitTestResult;
 import android.widget.Button;
 import android.widget.ImageView;
 import android.widget.TextView;
+import android.widget.Toast;
 
 import butterknife.ButterKnife;
 import butterknife.Bind;
@@ -40,6 +41,7 @@ import com.newsblur.domain.Classifier;
 import com.newsblur.domain.Story;
 import com.newsblur.domain.UserDetails;
 import com.newsblur.service.NBSyncService;
+import com.newsblur.service.OriginalTextService;
 import com.newsblur.util.DefaultFeedView;
 import com.newsblur.util.FeedSet;
 import com.newsblur.util.FeedUtils;
@@ -512,7 +514,19 @@ public class ReadingItemFragment extends NbFragment implements ClassifierDialogF
                 @Override
                 protected void onPostExecute(String result) {
                     if (result != null) {
-                        ReadingItemFragment.this.originalText = result;
+                        if (OriginalTextService.NULL_STORY_TEXT.equals(result)) {
+                            // the server reported that text mode is not available.  kick back to story mode
+                            UIUtils.safeToast(getActivity(), R.string.text_mode_unavailable, Toast.LENGTH_SHORT);
+                            synchronized (selectedFeedView) {
+                                selectedFeedView = DefaultFeedView.STORY;
+                                if (getActivity() != null) {
+                                    Reading activity = (Reading) getActivity();
+                                    activity.defaultFeedViewChanged(selectedFeedView);
+                                }
+                            }
+                        } else {
+                            ReadingItemFragment.this.originalText = result;
+                        }
                         reloadStoryContent();
                     } else {
                         if (getActivity() != null) setupWebview(getActivity().getResources().getString(R.string.orig_text_loading));

--- a/clients/android/NewsBlur/src/com/newsblur/fragment/ReadingItemFragment.java
+++ b/clients/android/NewsBlur/src/com/newsblur/fragment/ReadingItemFragment.java
@@ -484,17 +484,20 @@ public class ReadingItemFragment extends NbFragment implements ClassifierDialogF
         if (story == null) return;
         if (! TextUtils.equals(story.storyHash, this.story.storyHash)) return;
         this.story = story;
+        com.newsblur.util.Log.d(this.getClass().getName(), "got fresh story");
     }
 
     public void handleUpdate(int updateType) {
         if ((updateType & NbActivity.UPDATE_STORY) != 0) {
             updateSaveButton();
             updateShareButton();
+            setupItemCommentsAndShares();
         }
         if ((updateType & NbActivity.UPDATE_TEXT) != 0) {
             reloadStoryContent();
         }
         if ((updateType & NbActivity.UPDATE_SOCIAL) != 0) {
+            updateShareButton();
             setupItemCommentsAndShares();
         }
     }

--- a/clients/android/NewsBlur/src/com/newsblur/fragment/SetupCommentSectionTask.java
+++ b/clients/android/NewsBlur/src/com/newsblur/fragment/SetupCommentSectionTask.java
@@ -97,7 +97,7 @@ public class SetupCommentSectionTask extends AsyncTask<Void, Void, Void> {
 
 			View commentView = inflater.inflate(R.layout.include_comment, null);
 			TextView commentText = (TextView) commentView.findViewById(R.id.comment_text);
-			commentText.setText(UIUtils.fromHtml(comment.commentText));
+			commentText.setText(comment.commentText);
 			ImageView commentImage = (ImageView) commentView.findViewById(R.id.comment_user_image);
 
 			TextView commentSharedDate = (TextView) commentView.findViewById(R.id.comment_shareddate);
@@ -162,7 +162,7 @@ public class SetupCommentSectionTask extends AsyncTask<Void, Void, Void> {
 			for (final Reply reply : replies) {
 				View replyView = inflater.inflate(R.layout.include_reply, null);
 				TextView replyText = (TextView) replyView.findViewById(R.id.reply_text);
-				replyText.setText(UIUtils.fromHtml(reply.text));
+				replyText.setText(reply.text);
 				ImageView replyImage = (ImageView) replyView.findViewById(R.id.reply_user_image);
 
                 final UserProfile replyUser = FeedUtils.dbHelper.getUserProfile(reply.userId);

--- a/clients/android/NewsBlur/src/com/newsblur/fragment/SetupCommentSectionTask.java
+++ b/clients/android/NewsBlur/src/com/newsblur/fragment/SetupCommentSectionTask.java
@@ -141,18 +141,22 @@ public class SetupCommentSectionTask extends AsyncTask<Void, Void, Void> {
                 }
 			}
 
-			replyIcon.setOnClickListener(new OnClickListener() {
-				@Override
-				public void onClick(View v) {
-					if (story != null) {
-						UserProfile user = FeedUtils.dbHelper.getUserProfile(comment.userId);
-                        if (user != null) {
-                            DialogFragment newFragment = ReplyDialogFragment.newInstance(story, comment.userId, user.username);
-                            newFragment.show(manager, "dialog");
+            if (comment.isPlaceholder) {
+                replyIcon.setVisibility(View.INVISIBLE);
+            } else {
+                replyIcon.setOnClickListener(new OnClickListener() {
+                    @Override
+                    public void onClick(View v) {
+                        if (story != null) {
+                            UserProfile user = FeedUtils.dbHelper.getUserProfile(comment.userId);
+                            if (user != null) {
+                                DialogFragment newFragment = ReplyDialogFragment.newInstance(story, comment.userId, user.username);
+                                newFragment.show(manager, "dialog");
+                            }
                         }
-					}
-				}
-			});
+                    }
+                });
+            }
 
             List<Reply> replies = FeedUtils.dbHelper.getCommentReplies(comment.id);
 			for (final Reply reply : replies) {

--- a/clients/android/NewsBlur/src/com/newsblur/fragment/SetupCommentSectionTask.java
+++ b/clients/android/NewsBlur/src/com/newsblur/fragment/SetupCommentSectionTask.java
@@ -186,15 +186,19 @@ public class SetupCommentSectionTask extends AsyncTask<Void, Void, Void> {
                 }
 
                 ImageView editIcon = (ImageView) replyView.findViewById(R.id.reply_edit_icon);
-                editIcon.setOnClickListener(new OnClickListener() {
-                    @Override
-                    public void onClick(View v) {
-                        if (story != null) {
-                            DialogFragment newFragment = EditReplyDialogFragment.newInstance(story, comment.userId, reply.id, reply.text);
-                            newFragment.show(manager, "dialog");
+                if (TextUtils.equals(reply.userId, user.id)) {
+                    editIcon.setOnClickListener(new OnClickListener() {
+                        @Override
+                        public void onClick(View v) {
+                            if (story != null) {
+                                DialogFragment newFragment = EditReplyDialogFragment.newInstance(story, comment.userId, reply.id, reply.text);
+                                newFragment.show(manager, "dialog");
+                            }
                         }
-                    }
-                });
+                    });
+                } else {
+                    editIcon.setVisibility(View.INVISIBLE);
+                }
 
 
 				((LinearLayout) commentView.findViewById(R.id.comment_replies_container)).addView(replyView);

--- a/clients/android/NewsBlur/src/com/newsblur/fragment/ShareDialogFragment.java
+++ b/clients/android/NewsBlur/src/com/newsblur/fragment/ShareDialogFragment.java
@@ -67,11 +67,13 @@ public class ShareDialogFragment extends DialogFragment {
         commentEditText = (EditText) replyView.findViewById(R.id.comment_field);
 
         int positiveButtonText = R.string.share_this_story;
+        int negativeButtonText = R.string.alert_dialog_cancel;
         if (hasBeenShared) {
             positiveButtonText = R.string.update_shared;
             if (previousComment != null ) {
                 commentEditText.setText(previousComment.commentText);
             }
+            negativeButtonText = R.string.unshare;
         }
 
         builder.setPositiveButton(positiveButtonText, new DialogInterface.OnClickListener() {
@@ -82,12 +84,24 @@ public class ShareDialogFragment extends DialogFragment {
                 ShareDialogFragment.this.dismiss();
             }
         });
-        builder.setNegativeButton(R.string.alert_dialog_cancel, new DialogInterface.OnClickListener() {
-            @Override
-            public void onClick(DialogInterface dialogInterface, int i) {
-                ShareDialogFragment.this.dismiss();
-            }
-        });
+        if (hasBeenShared) {
+            // unshare
+            builder.setNegativeButton(negativeButtonText, new DialogInterface.OnClickListener() {
+                @Override
+                public void onClick(DialogInterface dialogInterface, int i) {
+                    FeedUtils.unshareStory(story, activity);
+                    ShareDialogFragment.this.dismiss();
+                }
+            });
+        } else {
+            // cancel
+            builder.setNegativeButton(negativeButtonText, new DialogInterface.OnClickListener() {
+                @Override
+                public void onClick(DialogInterface dialogInterface, int i) {
+                    ShareDialogFragment.this.dismiss();
+                }
+            });
+        }
         return builder.create();
     }
 

--- a/clients/android/NewsBlur/src/com/newsblur/network/APIConstants.java
+++ b/clients/android/NewsBlur/src/com/newsblur/network/APIConstants.java
@@ -46,6 +46,7 @@ public class APIConstants {
 	public static final String PATH_MARK_ALL_AS_READ = "/reader/mark_all_as_read/";
 	public static final String PATH_MARK_STORIES_READ = "/reader/mark_story_hashes_as_read/";
 	public static final String PATH_SHARE_STORY = "/social/share_story";
+	public static final String PATH_UNSHARE_STORY = "/social/unshare_story";
     public static final String PATH_MARK_STORY_AS_STARRED = "/reader/mark_story_hash_as_starred/";
     public static final String PATH_MARK_STORY_AS_UNSTARRED = "/reader/mark_story_hash_as_unstarred/";
     public static final String PATH_MARK_STORY_AS_UNREAD = "/reader/mark_story_as_unread/";

--- a/clients/android/NewsBlur/src/com/newsblur/network/APIConstants.java
+++ b/clients/android/NewsBlur/src/com/newsblur/network/APIConstants.java
@@ -69,6 +69,7 @@ public class APIConstants {
     public static final String PATH_CONNECT_FACEBOOK = "/oauth/facebook_connect/";
     public static final String PATH_CONNECT_TWITTER = "/oauth/twitter_connect/";
     public static final String PATH_SET_NOTIFICATIONS = "/notifications/feed/";
+    public static final String PATH_INSTA_FETCH = "/rss_feeds/exception_retry";
 
     public static String buildUrl(String path) {
         return CurrentUrlBase + path;
@@ -115,12 +116,14 @@ public class APIConstants {
     public static final String PARAMETER_APPROVED_FEEDS = "approved_feeds";
     public static final String PARAMETER_NOTIFICATION_TYPES = "notification_types";
     public static final String PARAMETER_NOTIFICATION_FILTER = "notification_filter";
+    public static final String PARAMETER_RESET_FETCH = "reset_fetch";
 
     public static final String VALUE_PREFIX_SOCIAL = "social:";
     public static final String VALUE_ALLSOCIAL = "river:blurblogs"; // the magic value passed to the mark-read API for all social feeds
     public static final String VALUE_OLDER = "older";
     public static final String VALUE_NEWER = "newer";
     public static final String VALUE_TRUE = "true";
+    public static final String VALUE_FALSE = "false";
     public static final String VALUE_STARRED = "starred";
 	
 	public static final String S3_URL_FEED_ICONS = "https://s3.amazonaws.com/icons.newsblur.com/";

--- a/clients/android/NewsBlur/src/com/newsblur/network/APIManager.java
+++ b/clients/android/NewsBlur/src/com/newsblur/network/APIManager.java
@@ -369,7 +369,7 @@ public class APIManager {
 		}
 	}
 
-	public NewsBlurResponse shareStory(final String storyId, final String feedId, final String comment, final String sourceUserId) {
+	public StoriesResponse shareStory(final String storyId, final String feedId, final String comment, final String sourceUserId) {
 		final ContentValues values = new ContentValues();
 		if (!TextUtils.isEmpty(comment)) {
 			values.put(APIConstants.PARAMETER_SHARE_COMMENT, comment);
@@ -381,7 +381,8 @@ public class APIManager {
 		values.put(APIConstants.PARAMETER_STORYID, storyId);
 
 		APIResponse response = post(buildUrl(APIConstants.PATH_SHARE_STORY), values);
-        return response.getResponse(gson, NewsBlurResponse.class);
+        // this call returns a new copy of the story with all fields updated and some metadata
+        return (StoriesResponse) response.getResponse(gson, StoriesResponse.class);
 	}
 
 	/**

--- a/clients/android/NewsBlur/src/com/newsblur/network/APIManager.java
+++ b/clients/android/NewsBlur/src/com/newsblur/network/APIManager.java
@@ -631,6 +631,15 @@ public class APIManager {
         return response.getResponse(gson, NewsBlurResponse.class);
     }
 
+    public NewsBlurResponse instaFetch(String feedId) {
+        ValueMultimap values = new ValueMultimap();
+        values.put(APIConstants.PARAMETER_FEEDID, feedId);
+        // this param appears fixed and mandatory for the call to succeed
+        values.put(APIConstants.PARAMETER_RESET_FETCH, APIConstants.VALUE_FALSE);
+        APIResponse response = post(buildUrl(APIConstants.PATH_INSTA_FETCH), values);
+        return response.getResponse(gson, NewsBlurResponse.class);
+    }
+
     /* HTTP METHODS */
    
 	private APIResponse get(final String urlString) {

--- a/clients/android/NewsBlur/src/com/newsblur/network/APIManager.java
+++ b/clients/android/NewsBlur/src/com/newsblur/network/APIManager.java
@@ -28,6 +28,7 @@ import com.newsblur.domain.Story;
 import com.newsblur.domain.ValueMultimap;
 import static com.newsblur.network.APIConstants.buildUrl;
 import com.newsblur.network.domain.ActivitiesResponse;
+import com.newsblur.network.domain.CommentResponse;
 import com.newsblur.network.domain.FeedFolderResponse;
 import com.newsblur.network.domain.InteractionsResponse;
 import com.newsblur.network.domain.LoginResponse;
@@ -543,14 +544,15 @@ public class APIManager {
         return response.getResponse(gson, NewsBlurResponse.class);
 	}
 
-	public NewsBlurResponse replyToComment(String storyId, String storyFeedId, String commentUserId, String reply) {
+	public CommentResponse replyToComment(String storyId, String storyFeedId, String commentUserId, String reply) {
 		ContentValues values = new ContentValues();
 		values.put(APIConstants.PARAMETER_STORYID, storyId);
 		values.put(APIConstants.PARAMETER_STORY_FEEDID, storyFeedId);
 		values.put(APIConstants.PARAMETER_COMMENT_USERID, commentUserId);
 		values.put(APIConstants.PARAMETER_REPLY_TEXT, reply);
 		APIResponse response = post(buildUrl(APIConstants.PATH_REPLY_TO), values);
-        return response.getResponse(gson, NewsBlurResponse.class);
+        // this call returns a new copy of the comment with all fields updated
+        return (CommentResponse) response.getResponse(gson, CommentResponse.class);
 	}
 
 	public NewsBlurResponse editReply(String storyId, String storyFeedId, String commentUserId, String replyId, String reply) {

--- a/clients/android/NewsBlur/src/com/newsblur/network/APIManager.java
+++ b/clients/android/NewsBlur/src/com/newsblur/network/APIManager.java
@@ -369,21 +369,31 @@ public class APIManager {
 		}
 	}
 
-	public StoriesResponse shareStory(final String storyId, final String feedId, final String comment, final String sourceUserId) {
-		final ContentValues values = new ContentValues();
-		if (!TextUtils.isEmpty(comment)) {
-			values.put(APIConstants.PARAMETER_SHARE_COMMENT, comment);
-		}
-		if (!TextUtils.isEmpty(sourceUserId)) {
-			values.put(APIConstants.PARAMETER_SHARE_SOURCEID, sourceUserId);
-		}
-		values.put(APIConstants.PARAMETER_FEEDID, feedId);
-		values.put(APIConstants.PARAMETER_STORYID, storyId);
+    public StoriesResponse shareStory(String storyId, String feedId, String comment, String sourceUserId) {
+        ContentValues values = new ContentValues();
+        if (!TextUtils.isEmpty(comment)) {
+            values.put(APIConstants.PARAMETER_SHARE_COMMENT, comment);
+        }
+        if (!TextUtils.isEmpty(sourceUserId)) {
+            values.put(APIConstants.PARAMETER_SHARE_SOURCEID, sourceUserId);
+        }
+        values.put(APIConstants.PARAMETER_FEEDID, feedId);
+        values.put(APIConstants.PARAMETER_STORYID, storyId);
 
-		APIResponse response = post(buildUrl(APIConstants.PATH_SHARE_STORY), values);
+        APIResponse response = post(buildUrl(APIConstants.PATH_SHARE_STORY), values);
         // this call returns a new copy of the story with all fields updated and some metadata
         return (StoriesResponse) response.getResponse(gson, StoriesResponse.class);
-	}
+    }
+
+    public StoriesResponse unshareStory(String storyId, String feedId) {
+        ContentValues values = new ContentValues();
+        values.put(APIConstants.PARAMETER_FEEDID, feedId);
+        values.put(APIConstants.PARAMETER_STORYID, storyId);
+
+        APIResponse response = post(buildUrl(APIConstants.PATH_UNSHARE_STORY), values);
+        // this call returns a new copy of the story with all fields updated and some metadata
+        return (StoriesResponse) response.getResponse(gson, StoriesResponse.class);
+    }
 
 	/**
      * Fetch the list of feeds/folders/socials from the backend.

--- a/clients/android/NewsBlur/src/com/newsblur/network/APIManager.java
+++ b/clients/android/NewsBlur/src/com/newsblur/network/APIManager.java
@@ -555,7 +555,7 @@ public class APIManager {
         return (CommentResponse) response.getResponse(gson, CommentResponse.class);
 	}
 
-	public NewsBlurResponse editReply(String storyId, String storyFeedId, String commentUserId, String replyId, String reply) {
+	public CommentResponse editReply(String storyId, String storyFeedId, String commentUserId, String replyId, String reply) {
 		ContentValues values = new ContentValues();
 		values.put(APIConstants.PARAMETER_STORYID, storyId);
 		values.put(APIConstants.PARAMETER_STORY_FEEDID, storyFeedId);
@@ -563,17 +563,19 @@ public class APIManager {
 		values.put(APIConstants.PARAMETER_REPLY_ID, replyId);
 		values.put(APIConstants.PARAMETER_REPLY_TEXT, reply);
 		APIResponse response = post(buildUrl(APIConstants.PATH_EDIT_REPLY), values);
-        return response.getResponse(gson, NewsBlurResponse.class);
+        // this call returns a new copy of the comment with all fields updated
+        return (CommentResponse) response.getResponse(gson, CommentResponse.class);
 	}
 
-	public NewsBlurResponse deleteReply(String storyId, String storyFeedId, String commentUserId, String replyId) {
+	public CommentResponse deleteReply(String storyId, String storyFeedId, String commentUserId, String replyId) {
 		ContentValues values = new ContentValues();
 		values.put(APIConstants.PARAMETER_STORYID, storyId);
 		values.put(APIConstants.PARAMETER_STORY_FEEDID, storyFeedId);
 		values.put(APIConstants.PARAMETER_COMMENT_USERID, commentUserId);
 		values.put(APIConstants.PARAMETER_REPLY_ID, replyId);
 		APIResponse response = post(buildUrl(APIConstants.PATH_DELETE_REPLY), values);
-        return response.getResponse(gson, NewsBlurResponse.class);
+        // this call returns a new copy of the comment with all fields updated
+        return (CommentResponse) response.getResponse(gson, CommentResponse.class);
 	}
 
 	public boolean addFeed(String feedUrl, String folderName) {

--- a/clients/android/NewsBlur/src/com/newsblur/network/domain/CommentResponse.java
+++ b/clients/android/NewsBlur/src/com/newsblur/network/domain/CommentResponse.java
@@ -1,0 +1,19 @@
+package com.newsblur.network.domain;
+
+import com.google.gson.annotations.SerializedName;
+
+import com.newsblur.domain.Comment;
+import com.newsblur.domain.UserProfile;
+
+/**
+ * API response binding for APIs that vend an updated Comment object.
+ */
+public class CommentResponse extends NewsBlurResponse {
+    
+    @SerializedName("comment")
+    public Comment comment;
+    
+    @SerializedName("user_profiles")
+    public UserProfile[] users;
+    
+}

--- a/clients/android/NewsBlur/src/com/newsblur/network/domain/NewsBlurResponse.java
+++ b/clients/android/NewsBlur/src/com/newsblur/network/domain/NewsBlurResponse.java
@@ -20,7 +20,8 @@ public class NewsBlurResponse {
     public boolean isError() {
         if (isProtocolError) return true;
         if ((message != null) && (!message.equals(""))) {
-            com.newsblur.util.Log.d(this.getClass().getName(), "Response interpreted as error due to 'message' field: " + message);
+            // NB: some valid POSTs use the message field for an error and some for a UX message, and we have no way of knowing the difference
+            com.newsblur.util.Log.d(this.getClass().getName(), "Response interpreted as fatal due to 'message' field: " + message);
             return true;
         }
         if ((errors != null) && (errors.length > 0) && (errors[0] != null)) {

--- a/clients/android/NewsBlur/src/com/newsblur/network/domain/StoriesResponse.java
+++ b/clients/android/NewsBlur/src/com/newsblur/network/domain/StoriesResponse.java
@@ -12,8 +12,13 @@ import com.newsblur.domain.UserProfile;
 
 public class StoriesResponse extends NewsBlurResponse {
 	
+    // some APIs (rivers) return many stories
 	@SerializedName("stories")
 	public Story[] stories;
+
+    // other APIs (shares) return a single updated story
+    @SerializedName("story")
+    public Story story;
 	
 	@SerializedName("user_profiles")
 	public UserProfile[] users;

--- a/clients/android/NewsBlur/src/com/newsblur/network/domain/UnreadCountResponse.java
+++ b/clients/android/NewsBlur/src/com/newsblur/network/domain/UnreadCountResponse.java
@@ -26,6 +26,15 @@ public class UnreadCountResponse extends NewsBlurResponse {
             values.put(DatabaseConstants.FEED_POSITIVE_COUNT, ps);
             values.put(DatabaseConstants.FEED_NEUTRAL_COUNT, nt);
             values.put(DatabaseConstants.FEED_NEGATIVE_COUNT, ng);
+            values.put(DatabaseConstants.FEED_FETCH_PENDING, false);
+            return values;
+        }
+
+        public ContentValues getValuesSocial() {
+            ContentValues values = new ContentValues();
+            values.put(DatabaseConstants.FEED_POSITIVE_COUNT, ps);
+            values.put(DatabaseConstants.FEED_NEUTRAL_COUNT, nt);
+            values.put(DatabaseConstants.FEED_NEGATIVE_COUNT, ng);
             return values;
         }
 

--- a/clients/android/NewsBlur/src/com/newsblur/service/NBSyncService.java
+++ b/clients/android/NewsBlur/src/com/newsblur/service/NBSyncService.java
@@ -351,7 +351,7 @@ public class NBSyncService extends Service {
                 if ((ra.getTried() > 0) && (PendingFeed != null)) continue actionsloop;
                     
                 com.newsblur.util.Log.d(this.getClass().getName(), "attempting action: " + ra.toContentValues().toString());
-                NewsBlurResponse response = ra.doRemote(apiManager);
+                NewsBlurResponse response = ra.doRemote(apiManager, dbHelper);
 
                 if (response == null) {
                     com.newsblur.util.Log.e(this.getClass().getName(), "Discarding reading action with client-side error.");
@@ -392,7 +392,7 @@ public class NBSyncService extends Service {
         if (AppConstants.VERBOSE_LOG) Log.d(this.getClass().getName(), "double-checking " + FollowupActions.size() + " actions");
         int impactFlags = 0;
         for (ReadingAction ra : FollowupActions) {
-            int impact = ra.doLocal(dbHelper);
+            int impact = ra.doLocal(dbHelper, true);
             impactFlags |= impact;
         }
         NbActivity.updateAllActivities(impactFlags);

--- a/clients/android/NewsBlur/src/com/newsblur/service/NBSyncService.java
+++ b/clients/android/NewsBlur/src/com/newsblur/service/NBSyncService.java
@@ -225,8 +225,13 @@ public class NBSyncService extends Service {
             Thread.currentThread().setName(this.getClass().getName());
 
             if (OfflineNow) {
-                OfflineNow = false;   
-                NbActivity.updateAllActivities(NbActivity.UPDATE_STATUS);
+                if (NetworkUtils.isOnline(this)) {
+                    OfflineNow = false;   
+                    NbActivity.updateAllActivities(NbActivity.UPDATE_STATUS);
+                } else {
+                    Log.d(this.getClass().getName(), "Abandoning sync: network still offline");
+                    return;
+                }
             }
 
             // do this even if background syncs aren't enabled, because it absolutely must happen

--- a/clients/android/NewsBlur/src/com/newsblur/service/NBSyncService.java
+++ b/clients/android/NewsBlur/src/com/newsblur/service/NBSyncService.java
@@ -363,7 +363,9 @@ public class NBSyncService extends Service {
                     noteHardAPIFailure();
                     continue actionsloop;
                 } else if (response.isError()) {
-                    com.newsblur.util.Log.e(this.getClass().getName(), "Discarding reading action with user error.");
+                    // the API responds with a message either if the call was a client-side error or if it was handled in such a
+                    // way that we should inform the user. in either case, it is considered complete.
+                    com.newsblur.util.Log.i(this.getClass().getName(), "Discarding reading action with fatal message.");
                     dbHelper.clearAction(id);
                     String message = response.getErrorMessage(null);
                     if (message != null) NbActivity.toastError(message);

--- a/clients/android/NewsBlur/src/com/newsblur/util/FeedUtils.java
+++ b/clients/android/NewsBlur/src/com/newsblur/util/FeedUtils.java
@@ -334,14 +334,22 @@ public class FeedUtils {
         context.startActivity(Intent.createChooser(intent, "Send using"));
     }
 
-	public static void shareStory(Story story, String comment, String sourceUserId, Context context) {
+    public static void shareStory(Story story, String comment, String sourceUserId, Context context) {
         if (story.sourceUserId != null) {
             sourceUserId = story.sourceUserId;
         }
         ReadingAction ra = ReadingAction.shareStory(story.storyHash, story.id, story.feedId, sourceUserId, comment);
         dbHelper.enqueueAction(ra);
         ra.doLocal(dbHelper);
-        NbActivity.updateAllActivities(NbActivity.UPDATE_SOCIAL);
+        NbActivity.updateAllActivities(NbActivity.UPDATE_SOCIAL | NbActivity.UPDATE_STORY);
+        triggerSync(context);
+    }
+
+    public static void unshareStory(Story story, Context context) {
+        ReadingAction ra = ReadingAction.unshareStory(story.storyHash, story.id, story.feedId);
+        dbHelper.enqueueAction(ra);
+        ra.doLocal(dbHelper);
+        NbActivity.updateAllActivities(NbActivity.UPDATE_SOCIAL | NbActivity.UPDATE_STORY);
         triggerSync(context);
     }
 

--- a/clients/android/NewsBlur/src/com/newsblur/util/FeedUtils.java
+++ b/clients/android/NewsBlur/src/com/newsblur/util/FeedUtils.java
@@ -448,6 +448,14 @@ public class FeedUtils {
         }.executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR);
     }
 
+    public static void instaFetchFeed(Context context, String feedId) {
+        ReadingAction ra = ReadingAction.instaFetch(feedId);
+        dbHelper.enqueueAction(ra);
+        ra.doLocal(dbHelper);
+        NbActivity.updateAllActivities(NbActivity.UPDATE_METADATA);
+        triggerSync(context);
+    }
+
     public static FeedSet feedSetFromFolderName(String folderName) {
         return FeedSet.folder(folderName, getFeedIdsRecursive(folderName));
     }

--- a/clients/android/NewsBlur/src/com/newsblur/util/Log.java
+++ b/clients/android/NewsBlur/src/com/newsblur/util/Log.java
@@ -53,6 +53,26 @@ public class Log {
 
     private Log() {} // util class - no instances
 
+    public static void d(Object src, String m) {
+        d(src.getClass().getName(), m);
+    }
+
+    public static void i(Object src, String m) {
+        i(src.getClass().getName(), m);
+    }
+
+    public static void w(Object src, String m) {
+        w(src.getClass().getName(), m);
+    }
+
+    public static void e(Object src, String m) {
+        e(src.getClass().getName(), m);
+    }
+
+    public static void e(Object src, String m, Throwable t) {
+        e(src.getClass().getName(), m, t);
+    }
+
     public static void d(String tag, String m) {
         if (AppConstants.VERBOSE_LOG) android.util.Log.d(tag, m);
         add(D, tag, m, null);

--- a/clients/android/NewsBlur/src/com/newsblur/util/ReadingAction.java
+++ b/clients/android/NewsBlur/src/com/newsblur/util/ReadingAction.java
@@ -418,7 +418,7 @@ public class ReadingAction implements Serializable {
             case SHARE:
                 StoriesResponse response = apiManager.shareStory(storyId, feedId, commentReplyText, sourceUserId);
                 if ((response != null) && (response.story != null)) {
-                    dbHelper.insertStories(response, true);
+                    dbHelper.updateStory(response, true);
                     impact |= NbActivity.UPDATE_SOCIAL;
                 } else {
                     com.newsblur.util.Log.i(this.getClass().getName(), "share failed to refresh story");
@@ -429,7 +429,7 @@ public class ReadingAction implements Serializable {
             case UNSHARE:
                 StoriesResponse unshareResponse = apiManager.unshareStory(storyId, feedId);
                 if ((unshareResponse != null) && (unshareResponse.story != null)) {
-                    dbHelper.insertStories(unshareResponse, true);
+                    dbHelper.updateStory(unshareResponse, true);
                     impact |= NbActivity.UPDATE_SOCIAL;
                 } else {
                     com.newsblur.util.Log.i(this.getClass().getName(), "unshare failed to refresh story");

--- a/clients/android/NewsBlur/src/com/newsblur/util/ReadingAction.java
+++ b/clients/android/NewsBlur/src/com/newsblur/util/ReadingAction.java
@@ -532,14 +532,12 @@ public class ReadingAction implements Serializable {
                 break;
 
             case LIKE_COMMENT:
-                // TODO need to use real comment ID
-                // dbHelper.setCommentLiked(storyId, commentUserId, feedId, true);
+                dbHelper.setCommentLiked(storyId, commentUserId, feedId, true);
                 impact |= NbActivity.UPDATE_SOCIAL;
                 break;
 
             case UNLIKE_COMMENT:
-                // TODO need to use real comment ID
-                // dbHelper.setCommentLiked(storyId, commentUserId, feedId, false);
+                dbHelper.setCommentLiked(storyId, commentUserId, feedId, false);
                 impact |= NbActivity.UPDATE_SOCIAL;
                 break;
 

--- a/clients/android/NewsBlur/src/com/newsblur/util/UIUtils.java
+++ b/clients/android/NewsBlur/src/com/newsblur/util/UIUtils.java
@@ -151,15 +151,19 @@ public class UIUtils {
      * before the task completes, resulting in a crash.  This prevents the crash at the 
      * cost of the toast not being shown.
      */
-    public static void safeToast(Context c, int rid, int duration) {
+    public static void safeToast(final Activity c, final int rid, final int duration) {
         if (c != null) {
-            Toast.makeText(c, rid, duration).show();
+            c.runOnUiThread(new Runnable() { public void run() {
+                Toast.makeText(c, rid, duration).show();
+            }});
         }
     }
 
-    public static void safeToast(Context c, String text, int duration) {
+    public static void safeToast(final Activity c, final String text, final int duration) {
         if ((c != null) && (text != null)) {
-            Toast.makeText(c, text, duration).show();
+            c.runOnUiThread(new Runnable() { public void run() {
+                Toast.makeText(c, text, duration).show();
+            }});
         }
     }
 


### PR DESCRIPTION
* Proper fixes for the issues discovered with social features last month.  All social features should now be working as intended with a snappy local UX, full async/offline support, and immediate/intermediate/final state that matches the web UI.  Also added the missing functions for deleting and editing comments and replies.
* Fixed the broken no-focus-unreads explainer; added some logging to help us quickly diagnose user confusion about focus mode.
* Improved handling of stories with failed original text extraction. Now messages user and switches them back to a mode with content to view.
* Implemented insta-fetch for feeds. (#1032)
* Various non-critical bug fixes.

Should be ready for a week in Beta and then a week in 10% rollout, at least.
