### PR TITLE
Firefox Fix: change host to match Firefox iOS app change

### DIFF
--- a/clients/ios/Classes/NewsBlurAppDelegate.m
+++ b/clients/ios/Classes/NewsBlurAppDelegate.m
@@ -1710,7 +1710,7 @@
         return;
     } else if ([storyBrowser isEqualToString:@"firefox"]) {
         NSString *encodedURL = [url.absoluteString stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLHostAllowedCharacterSet]];
-        NSString *firefoxURL = [NSString stringWithFormat:@"%@%@", @"firefox://?url=", encodedURL];
+        NSString *firefoxURL = [NSString stringWithFormat:@"%@%@", @"firefox://open-url?url=", encodedURL];
         [[UIApplication sharedApplication] openURL:[NSURL URLWithString:firefoxURL] options:@{} completionHandler:nil];
     } else if ([storyBrowser isEqualToString:@"inappsafari"]) {
         self.safariViewController = [[SFSafariViewController alloc] initWithURL:url


### PR DESCRIPTION
There was a change to the Firefox iOS app where linking now requires a host of "open-url". This change broke linking to firefox from newsblur and this PR addresses the issue.

The corresponding code in Firefox is here: https://github.com/mozilla-mobile/firefox-ios/blob/master/Client/Application/AppDelegate.swift#L393