### PR TITLE
favicon fetcher: provide an Accept header on requests.

### DIFF
--- a/apps/rss_feeds/icon_importer.py
+++ b/apps/rss_feeds/icon_importer.py
@@ -269,6 +269,7 @@ class IconImporter(object):
                                   self.feed.permalink
                               ),
                 'Connection': 'close',
+                'Accept': 'image/png,image/x-icon,image/*;q=0.9,*/*;q=0.8'
             }
             try:
                 request = urllib2.Request(url, headers=headers)


### PR DESCRIPTION
This makes the fetcher work with the default ModSecurity ruleset, and would also avoid providing unsupported favicon formats (e.g. webp), by explictly preferring PNG and
x-icon formats.