### PR TITLE
iOS: Fix duplicate title/URL in Messages sharing.

### DIFF
--- a/clients/ios/Classes/NBActivityItemSource.m
+++ b/clients/ios/Classes/NBActivityItemSource.m
@@ -29,6 +29,8 @@
 -(id)activityViewController:(UIActivityViewController *)activityViewController itemForActivityType:(NSString *)activityType {
     if ([activityType isEqualToString:UIActivityTypeMail]) {
         return text;
+    } else if ([activityType isEqualToString:UIActivityTypeMessage]) {
+        return url;
     } else if ([activityType isEqualToString:@"com.evernote.iPhone.Evernote.EvernoteShare"]) {
         return @{@"body": text ?: (url ?: @""), @"subject": title};
     } else if ([activityType isEqualToString:UIActivityTypeAddToReadingList] ||


### PR DESCRIPTION
Now Messages displays URL previews, just don’t include the title at all any more.

See https://getsatisfaction.com/newsblur/topics/app-share-sheet-duplicates-urls-shared.