### PR TITLE
Docker: Use mongo:3.2 docker image in docker-compose.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,7 +35,7 @@ services:
       - '9200:9200'
 
   mongo:
-    image: mongo:3
+    image: mongo:3.2
     ports:
       - '27017:27017'
     command: mongod --smallfiles


### PR DESCRIPTION
Mongo 3.4 does not work properly with pymongo, so pin the mongo docker image to v3.2.