### PR TITLE
Web: Changed whitespace break behavior in the feed title

### DIFF
--- a/media/css/reader.css
+++ b/media/css/reader.css
@@ -690,7 +690,7 @@ a img {
     text-overflow: ellipsis;
     -webkit-line-clamp: 1;
     -webkit-box-orient: vertical;
-    display: -webkit-box;
+    white-space: nowrap;
 }
 
 .NB-feedlist .feed .NB-feedlist-manage-icon,


### PR DESCRIPTION
Fix for issue #1058. 
Needed to remove "display: -webkit-box", because "text-overflow: ellipsis" only works with "display: block".