### PR TITLE
Android: Make Some Meta-Folders Optional

### DIFF
--- a/clients/android/NewsBlur/res/values/strings.xml
+++ b/clients/android/NewsBlur/res/values/strings.xml
@@ -236,6 +236,13 @@
     </string-array>
     <string name="default_network_select_value">NOMONONME</string>
 
+    <string name="settings_cat_feed_list">Feed List</string>
+
+    <string name="settings_enable_row_global_shared">Show Global Shared Stories</string>
+    <string name="settings_enable_row_global_shared_sum">Show the Global Shared Stories folder</string>
+    <string name="settings_enable_row_infrequent_stories">Show Infrequent Stories Stories</string>
+    <string name="settings_enable_row_infrequent_stories_sum">Show the Infrequent Site Stories Stories folder</string>
+
     <string name="settings_cat_story_list">Story List</string>
 
     <string name="oldest">Oldest</string>

--- a/clients/android/NewsBlur/res/xml/activity_settings.xml
+++ b/clients/android/NewsBlur/res/xml/activity_settings.xml
@@ -28,6 +28,22 @@
             android:summary="@string/settings_keep_old_stories_sum" />
     </PreferenceCategory>
 
+    <PreferenceCategory
+        android:title="@string/settings_cat_feed_list">
+        <CheckBoxPreference
+            android:defaultValue="true"
+            android:key="enable_row_global_shared"
+            android:title="@string/settings_enable_row_global_shared" 
+            android:summary="@string/settings_enable_row_global_shared_sum"
+            />
+        <CheckBoxPreference
+            android:defaultValue="true"
+            android:key="enable_row_infrequent_stories"
+            android:title="@string/settings_enable_row_infrequent_stories" 
+            android:summary="@string/settings_enable_row_infrequent_stories_sum"
+            />
+    </PreferenceCategory>
+
     <PreferenceCategory 
         android:title="@string/settings_cat_story_list">
         <ListPreference

--- a/clients/android/NewsBlur/src/com/newsblur/database/FolderListAdapter.java
+++ b/clients/android/NewsBlur/src/com/newsblur/database/FolderListAdapter.java
@@ -579,10 +579,10 @@ public class FolderListAdapter extends BaseExpandableListAdapter {
         folderNeutCounts = new ArrayList<Integer>();
         folderPosCounts = new ArrayList<Integer>();
         // add the always-present (if enabled) special rows/folders that got at the top of the list
-        if (PrefsUtils.isEnableRowGlobalShared(context)) addSpecialRow(GLOBAL_SHARED_STORIES_GROUP_KEY);
-        addSpecialRow(ALL_SHARED_STORIES_GROUP_KEY);
+        if (PrefsUtils.isEnableRowGlobalShared(context) && (currentState != StateFilter.SAVED)) addSpecialRow(GLOBAL_SHARED_STORIES_GROUP_KEY);
+        if ((currentState != StateFilter.SAVED)) addSpecialRow(ALL_SHARED_STORIES_GROUP_KEY);
         addSpecialRow(ALL_STORIES_GROUP_KEY);
-        if (PrefsUtils.isEnableRowInfrequent(context)) addSpecialRow(INFREQUENT_SITE_STORIES_GROUP_KEY);
+        if (PrefsUtils.isEnableRowInfrequent(context) && (currentState != StateFilter.SAVED)) addSpecialRow(INFREQUENT_SITE_STORIES_GROUP_KEY);
         // create a sorted list of folder display names
         List<String> sortedFolderNames = new ArrayList<String>(flatFolders.keySet());
         Collections.sort(sortedFolderNames, Folder.FolderNameComparator);

--- a/clients/android/NewsBlur/src/com/newsblur/database/FolderListAdapter.java
+++ b/clients/android/NewsBlur/src/com/newsblur/database/FolderListAdapter.java
@@ -385,6 +385,7 @@ public class FolderListAdapter extends BaseExpandableListAdapter {
      * Supports normal folders only, not special all-type meta-folders.
      */
     public String getGroupFolderName(int groupPosition) {
+        if (isRowRootFolder(groupPosition)) return AppConstants.ROOT_FOLDER;
         String flatFolderName = activeFolderNames.get(groupPosition);
         Folder folder = flatFolders.get(flatFolderName);
         return folder.name;

--- a/clients/android/NewsBlur/src/com/newsblur/fragment/FolderListFragment.java
+++ b/clients/android/NewsBlur/src/com/newsblur/fragment/FolderListFragment.java
@@ -244,12 +244,12 @@ public class FolderListFragment extends NbFragment implements OnCreateContextMen
             if (adapter.isRowSavedStories(groupPosition)) break;
             if (currentState == StateFilter.SAVED) break;
             if (adapter.isRowReadStories(groupPosition)) break;
-            if (groupPosition == FolderListAdapter.GLOBAL_SHARED_STORIES_GROUP_POSITION) break;
-            if (groupPosition == FolderListAdapter.ALL_SHARED_STORIES_GROUP_POSITION) break;
-            if (groupPosition == FolderListAdapter.INFREQUENT_SITE_STORIES_GROUP_POSITION) break;
+            if (adapter.isRowGlobalSharedStories(groupPosition)) break;
+            if (adapter.isRowAllSharedStories(groupPosition)) break;
+            if (adapter.isRowInfrequentStories(groupPosition)) break;
             inflater.inflate(R.menu.context_folder, menu);
 
-            if (groupPosition == FolderListAdapter.ALL_STORIES_GROUP_POSITION) {
+            if (adapter.isRowAllStories(groupPosition)) {
                 menu.removeItem(R.id.menu_mute_folder);
                 menu.removeItem(R.id.menu_unmute_folder);
             }
@@ -260,7 +260,7 @@ public class FolderListFragment extends NbFragment implements OnCreateContextMen
             if (adapter.isRowSavedStories(groupPosition)) break;
             if (currentState == StateFilter.SAVED) break;
 			inflater.inflate(R.menu.context_feed, menu);
-            if (groupPosition == FolderListAdapter.ALL_SHARED_STORIES_GROUP_POSITION) {
+            if (adapter.isRowAllSharedStories(groupPosition)) {
                 menu.removeItem(R.id.menu_delete_feed);
                 menu.removeItem(R.id.menu_choose_folders);
                 menu.removeItem(R.id.menu_unmute_feed);
@@ -329,7 +329,7 @@ public class FolderListFragment extends NbFragment implements OnCreateContextMen
 
 		if (item.getItemId() == R.id.menu_delete_feed || item.getItemId() == R.id.menu_unfollow) {
 			DialogFragment deleteFeedFragment;
-            if (groupPosition == FolderListAdapter.ALL_SHARED_STORIES_GROUP_POSITION) {
+            if (adapter.isRowAllSharedStories(groupPosition)) {
                 deleteFeedFragment = DeleteFeedFragment.newInstance(adapter.getSocialFeed(groupPosition, childPosition));
             } else {
                 String folderName = adapter.getGroupFolderName(groupPosition);
@@ -417,7 +417,7 @@ public class FolderListFragment extends NbFragment implements OnCreateContextMen
 	@Override
     public boolean onGroupClick(ExpandableListView list, View group, int groupPosition, long id) {
         Intent i = null;
-        if (groupPosition == FolderListAdapter.ALL_STORIES_GROUP_POSITION) {
+        if (adapter.isRowAllStories(groupPosition)) {
             if (currentState == StateFilter.SAVED) {
                 // the existence of this row in saved mode is something of a framework artifact and may
                 // confuse users. redirect them to the activity corresponding to what they will actually see
@@ -425,11 +425,11 @@ public class FolderListFragment extends NbFragment implements OnCreateContextMen
             } else {
 			    i = new Intent(getActivity(), AllStoriesItemsList.class);
             }
-        } else if (groupPosition == FolderListAdapter.GLOBAL_SHARED_STORIES_GROUP_POSITION) {
+        } else if (adapter.isRowGlobalSharedStories(groupPosition)) {
             i = new Intent(getActivity(), GlobalSharedStoriesItemsList.class);
-        } else if (groupPosition == FolderListAdapter.ALL_SHARED_STORIES_GROUP_POSITION) {
+        } else if (adapter.isRowAllSharedStories(groupPosition)) {
             i = new Intent(getActivity(), AllSharedStoriesItemsList.class);
-        } else if (groupPosition == FolderListAdapter.INFREQUENT_SITE_STORIES_GROUP_POSITION) {
+        } else if (adapter.isRowInfrequentStories(groupPosition)) {
             i = new Intent(getActivity(), InfrequentItemsList.class);
         } else if (adapter.isRowReadStories(groupPosition)) {
             i = new Intent(getActivity(), ReadStoriesItemsList.class);
@@ -456,7 +456,7 @@ public class FolderListFragment extends NbFragment implements OnCreateContextMen
     @Override
     public void onGroupExpand(int groupPosition) {
         // these shouldn't ever be collapsible
-        if (adapter.isFolderRoot(groupPosition)) return;
+        if (adapter.isRowRootFolder(groupPosition)) return;
         if (adapter.isRowReadStories(groupPosition)) return;
 
         String flatGroupName = adapter.getGroupUniqueName(groupPosition);
@@ -474,7 +474,7 @@ public class FolderListFragment extends NbFragment implements OnCreateContextMen
     @Override
     public void onGroupCollapse(int groupPosition) {
         // these shouldn't ever be collapsible
-        if (adapter.isFolderRoot(groupPosition)) return;
+        if (adapter.isRowRootFolder(groupPosition)) return;
         if (adapter.isRowReadStories(groupPosition)) return;
 
         String flatGroupName = adapter.getGroupUniqueName(groupPosition);
@@ -490,7 +490,7 @@ public class FolderListFragment extends NbFragment implements OnCreateContextMen
 	@Override
     public boolean onChildClick(ExpandableListView list, View childView, int groupPosition, int childPosition, long id) {
         FeedSet fs = adapter.getChild(groupPosition, childPosition);
-		if (groupPosition == FolderListAdapter.ALL_SHARED_STORIES_GROUP_POSITION) {
+		if (adapter.isRowAllSharedStories(groupPosition)) {
             SocialFeed socialFeed = adapter.getSocialFeed(groupPosition, childPosition);
 			Intent intent = new Intent(getActivity(), SocialFeedItemsList.class);
             intent.putExtra(ItemsList.EXTRA_FEED_SET, fs);

--- a/clients/android/NewsBlur/src/com/newsblur/util/PrefConstants.java
+++ b/clients/android/NewsBlur/src/com/newsblur/util/PrefConstants.java
@@ -67,6 +67,9 @@ public class PrefConstants {
     public static final String NETWORK_SELECT_NOMO = "NOMO";
     public static final String NETWORK_SELECT_NOMONONME = "NOMONONME";
 
+    public static final String ENABLE_ROW_GLOBAL_SHARED = "enable_row_global_shared";
+    public static final String ENABLE_ROW_INFREQUENT_STORIES = "enable_row_infrequent_stories";
+
     public static final String THEME = "theme";
 
     public static final String STATE_FILTER = "state_filter";

--- a/clients/android/NewsBlur/src/com/newsblur/util/PrefsUtils.java
+++ b/clients/android/NewsBlur/src/com/newsblur/util/PrefsUtils.java
@@ -389,6 +389,16 @@ public class PrefsUtils {
         return ReadFilter.valueOf(prefs.getString(PrefConstants.DEFAULT_READ_FILTER, ReadFilter.ALL.toString()));
     }
 
+    public static boolean isEnableRowGlobalShared(Context context) {
+        SharedPreferences prefs = context.getSharedPreferences(PrefConstants.PREFERENCES, 0);
+        return prefs.getBoolean(PrefConstants.ENABLE_ROW_GLOBAL_SHARED, true);
+    }
+
+    public static boolean isEnableRowInfrequent(Context context) {
+        SharedPreferences prefs = context.getSharedPreferences(PrefConstants.PREFERENCES, 0);
+        return prefs.getBoolean(PrefConstants.ENABLE_ROW_INFREQUENT_STORIES, true);
+    }
+
     public static boolean showPublicComments(Context context) {
         SharedPreferences prefs = context.getSharedPreferences(PrefConstants.PREFERENCES, 0);
         return prefs.getBoolean(PrefConstants.SHOW_PUBLIC_COMMENTS, true);


### PR DESCRIPTION
As discussed in #1065, a quick patch to make optional some meta-folders that have been causing a bad UX for some folks.