### PR TITLE
iOS: Replace “magic number” 0-3 section indices with constants

### DIFF
--- a/clients/ios/Classes/FolderTitleView.m
+++ b/clients/ios/Classes/FolderTitleView.m
@@ -37,14 +37,7 @@
         [subview removeFromSuperview];
     }
     
-    NSString *folderName;
-    if (section == 0) {
-        folderName = @"river_global";
-    } else if (section == 1) {
-        folderName = @"river_blurblogs";
-    } else {
-        folderName = [appDelegate.dictFoldersArray objectAtIndex:section];
-    }
+    NSString *folderName = appDelegate.dictFoldersArray[section];
     NSString *collapseKey = [NSString stringWithFormat:@"folderCollapsed:%@", folderName];
     bool isFolderCollapsed = [userPreferences boolForKey:collapseKey];
     NSInteger countWidth = 0;
@@ -115,13 +108,13 @@
     UIFont *font = [UIFont fontWithDescriptor: boldFontDescriptor size:0.0];
     NSInteger titleOffsetY = ((rect.size.height - font.pointSize) / 2) - 1;
     NSString *folderTitle;
-    if (section == 0) {
+    if (section == NewsBlurTopSectionGlobalSharedStories) {
         folderTitle = [@"Global Shared Stories" uppercaseString];
-    } else if (section == 1) {
-            folderTitle = [@"All Shared Stories" uppercaseString];
-    } else if (section == 2) {
+    } else if (section == NewsBlurTopSectionAllSharedStories) {
+        folderTitle = [@"All Shared Stories" uppercaseString];
+    } else if (section == NewsBlurTopSectionInfrequentSiteStories) {
         folderTitle = [@"Infrequent Site Stories" uppercaseString];
-    } else if (section == 3) {
+    } else if (section == NewsBlurTopSectionAllStories) {
         folderTitle = [@"All Stories" uppercaseString];
     } else if ([folderName isEqual:@"read_stories"]) {
         folderTitle = [@"Read Stories" uppercaseString];

--- a/clients/ios/Classes/NewsBlurViewController.h
+++ b/clients/ios/Classes/NewsBlurViewController.h
@@ -14,6 +14,15 @@
 #import "IASKAppSettingsViewController.h"
 #import "MCSwipeTableViewCell.h"
 
+// indices in appDelegate.dictFoldersArray and button tags
+// keep in sync with NewsBlurTopSectionNames
+static enum {
+    NewsBlurTopSectionGlobalSharedStories = 0,
+    NewsBlurTopSectionAllSharedStories = 1,
+    NewsBlurTopSectionInfrequentSiteStories = 2,
+    NewsBlurTopSectionAllStories = 3
+} NewsBlurTopSection;
+
 @class NewsBlurAppDelegate;
 
 @interface NewsBlurViewController : BaseViewController


### PR DESCRIPTION
These indices are used in appDelegate.dictFoldersArray and as UIButton tags.

Removes a number of places where a number-to-name lookup was done for no apparent reason when the items are in appDelegate.dictFoldersArray already.

Fixes issue where all stories are now at index 3, not 2, and shift-E was showing infrequent site stories on iPad because the index was not updated when infrequent site stories were introduced.