### PR TITLE
Updating Dockerfile to use default-libmysqlclient-dev

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -23,7 +23,7 @@ RUN       set -ex \
                     libblas-dev \
                     libffi-dev \
                     libjpeg-dev \
-                    libmysqlclient-dev \
+                    default-libmysqlclient-dev \
                     libpq-dev \
                     libreadline6-dev \
                     liblapack-dev \


### PR DESCRIPTION
Address issue #1113 by replacing `libmysqlclient-dev` with `default-libmysqlclient-dev` 