### PR TITLE
Docker:  docker-compose: Add front/back networks and persistent config storage

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,9 @@ services:
       - redis
     ports:
       - '8000:8000'
+    networks:
+      - front
+      - back
 
   postgres:
     image: postgres:9
@@ -23,19 +26,56 @@ services:
       - '5432:5432'
     volumes:
       - ./docker/postgres:/docker-entrypoint-initdb.d
+      - ./docker/volumes/postgres:/var/lib/postgresql/data
+    networks:
+      - back
 
   redis:
     image: redis:3
     ports:
       - '6379:6379'
+    volumes:
+      - ./docker/volumes/redis:/data
+      - ./config/redis.conf:/usr/local/etc/redis_server.conf
+      - ./config/redis_docker.conf:/etc/redis_server.conf
+      - ./docker/volumes/redis.var.lib:/var/lib/redis
+    command: /usr/local/bin/redis-server /usr/local/etc/redis_server.conf
+    networks:
+      - back
+
 
   elasticsearch:
     image: elasticsearch:1.7
     ports:
       - '9200:9200'
+    volumes:
+      - ./docker/volumes/elasticsearch:/usr/share/elasticsearch/data
+    networks:
+      - back
 
   mongo:
     image: mongo:3.2
     ports:
       - '27017:27017'
     command: mongod --smallfiles
+    volumes:
+      - ./docker/volumes/mongo:/data/db
+    networks:
+      - back
+
+networks:
+    front:
+      driver: bridge
+# Note: below is optional, if you have an existing ingress bridge
+#      config:
+#        external:
+#            name: ingress
+    back:
+      driver: bridge
+      ipam:
+        driver: default
+# Note: below is optional, if you'd like the back bridge to use fewer IP addresses
+#        config:
+#        - subnet: 172.16.128.0/24
+#          gateway: 172.16.128.1
+      internal: true


### PR DESCRIPTION
This PR does two things for using NewsBlur with docker-compose:

1. Importantly, this PR puts Redis (along with postgres, elasticsearch and mongo) on an internal-only network. This is especially important as by default Redis isn't using a password, and if you happen to have this on a public IP address, miscreants from around the world will mess with your Redis instance.

2. This PR also puts as volumes the remaining configs for the different backends.
