### PR TITLE
Docker Compose Redis exits immediately

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,4 @@ clients/android/NewsBlur/.gradle
 clients/android/NewsBlur/build.gradle
 clients/android/NewsBlur/gradle*
 clients/android/NewsBlur/settings.gradle
+/docker/volumes/*

--- a/config/redis.conf
+++ b/config/redis.conf
@@ -14,11 +14,11 @@
 
 # By default Redis does not run as a daemon. Use 'yes' if you need it.
 # Note that Redis will write a pid file in /var/run/redis.pid when daemonized.
-daemonize yes
+daemonize no
 
 # When running daemonized, Redis writes a pid file in /var/run/redis.pid by
 # default. You can specify a custom pid file location here.
-pidfile /var/run/redis.pid
+#pidfile /var/run/redis.pid
 
 # Accept connections on the specified port, default is 6379.
 # If port 0 is specified Redis will not listen on a TCP socket.


### PR DESCRIPTION
This PR addresses the #1144 

It just avoids demonizing the redis service inside the container to hold it up.