### PR TITLE
ignore Chromium's dark mode settings

### DIFF
--- a/clients/android/NewsBlur/assets/light_reading.css
+++ b/clients/android/NewsBlur/assets/light_reading.css
@@ -18,3 +18,9 @@ pre, blockquote {
     background-color: #F2F2F2;
     color: rgba(10, 12, 38, .8);
 }
+/* do not adhere to Chromium's color scheme settings */
+@media(prefers-color-scheme: dark){
+    body {
+        background-color: #FFF;
+    }
+}


### PR DESCRIPTION
This fixes #1179 

The issue was due to the progressive rollout of dark mode. The fix uses the new `prefers-color-scheme` [CSS media query](https://developers.google.com/web/updates/2019/03/nic73) to bypass dark mode and prevent chromium from inverting the background.

It is based on v8.0.0 61eb724cbb682f67ef871bce66597632ad491cea , which is currently on the production track on Google Play, so it does not contain the beta features in v9b1.