### PR TITLE
upgrade api version

### DIFF
--- a/clients/android/NewsBlur/AndroidManifest.xml
+++ b/clients/android/NewsBlur/AndroidManifest.xml
@@ -6,7 +6,7 @@
 
     <uses-sdk
         android:minSdkVersion="21"
-        android:targetSdkVersion="26" />
+        android:targetSdkVersion="28" />
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />


### PR DESCRIPTION
As mentioned in #1178 this just bumps the Android API version so we can submit to Google Play.

It will be important to monitor potential performance issues, and quirks from the new jobs synchronization logic. I'll be watching those.