### PR TITLE
ignore Chromium's dark mode settings, including html tag

### DIFF
--- a/clients/android/NewsBlur/assets/light_reading.css
+++ b/clients/android/NewsBlur/assets/light_reading.css
@@ -1,4 +1,4 @@
-body {
+body, html {
 	background-color: #FFF;
 }
 
@@ -20,7 +20,7 @@ pre, blockquote {
 }
 /* do not adhere to Chromium's color scheme settings */
 @media(prefers-color-scheme: dark){
-    body {
+    body, html {
         background-color: #FFF;
     }
 }


### PR DESCRIPTION
chrome's dark mode updated to ignore the body tag, adding the html tag fixes it