### PR TITLE
set primary text color globally

### DIFF
--- a/clients/android/NewsBlur/res/values/theme.xml
+++ b/clients/android/NewsBlur/res/values/theme.xml
@@ -41,6 +41,7 @@
         <item name="selectorOverlayBackgroundText">@style/selectorOverlayBackgroundText</item>
         <item name="muteicon">@style/muteicon</item>
         <item name="android:contextPopupMenuStyle">@style/contextPopupStyle</item>
+        <item name="android:textColorPrimary">@color/black</item>
 	</style>
 
     <style name="NewsBlurDarkTheme" parent="@android:style/Theme.Holo" >
@@ -83,7 +84,10 @@
         <item name="selectorOverlayBackgroundStory">@style/selectorOverlayBackgroundStory.dark</item>
         <item name="selectorOverlayBackgroundText">@style/selectorOverlayBackgroundText.dark</item>
         <item name="muteicon">@style/muteicon.dark</item>
+
+        <!--requires API 24-->
         <item name="android:contextPopupMenuStyle">@style/contextPopupStyle.dark</item>
+        <item name="android:textColorPrimary">@color/white</item>
     </style>
 
     <style name="NewsBlurBlackTheme" parent="@android:style/Theme.Holo" >
@@ -127,5 +131,6 @@
         <item name="selectorOverlayBackgroundText">@style/selectorOverlayBackgroundText.dark</item>
         <item name="muteicon">@style/muteicon.dark</item>
         <item name="android:contextPopupMenuStyle">@style/contextPopupStyle.dark</item>
+        <item name="android:textColorPrimary">@color/white</item>
     </style>
 </resources>


### PR DESCRIPTION
this is to allow the holo theme to read the color value for places
where our themes do not touch, like menu text

This should resolve #1145 