### PR TITLE
remove clearing of fullscreen on window focus change

### DIFF
--- a/clients/android/NewsBlur/src/com/newsblur/activity/Reading.java
+++ b/clients/android/NewsBlur/src/com/newsblur/activity/Reading.java
@@ -587,10 +587,6 @@ public abstract class Reading extends NbActivity implements OnPageChangeListener
         // this callback is a good API-level-independent way to tell when the root view size/layout changes
         super.onWindowFocusChanged(hasFocus);
         this.contentView = findViewById(android.R.id.content);
-        // Ensure that we come out of immersive view if the activity no longer has focus
-        if (!hasFocus) {
-            ViewUtils.showSystemUI(getWindow().getDecorView());
-        }
     }
 
 	/**


### PR DESCRIPTION
android docs indicate that any system window can take focus from the activity, so we should not clear full screen in that case; the system will handle it if necessary (e.g. user leaves application, swipes navigation back up)

fixes #1200 