### PR TITLE
use system formatted date for non-english locales

### DIFF
--- a/clients/android/NewsBlur/src/com/newsblur/util/StoryUtils.java
+++ b/clients/android/NewsBlur/src/com/newsblur/util/StoryUtils.java
@@ -6,6 +6,7 @@ import android.text.format.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.Calendar;
 import java.util.Date;
+import java.util.Locale;
 
 /**
  * Created by mark on 04/02/2014.
@@ -67,6 +68,20 @@ public class StoryUtils {
         int month = storyCalendar.get(Calendar.DAY_OF_MONTH);
 
         SimpleDateFormat timeFormat = getTimeFormat(context);
+        Locale locale = context.getResources().getConfiguration().locale;
+
+        if(!locale.getLanguage().equals("en")){
+            String pattern = null;
+
+            if (storyDate.getTime() > beginningOfMonth.getTime()) {
+                // localized pattern, without year
+                pattern = android.text.format.DateFormat.getBestDateTimePattern(locale, "EEEE MMMM d");
+            }else {
+                // localized pattern, with year
+                pattern = android.text.format.DateFormat.getBestDateTimePattern(locale, "EEEE MMMM d yyyy");
+            }
+            return DateFormat.format(pattern, storyDate).toString() + " " + timeFormat.format(storyDate);
+        }
 
         if (storyDate.getTime() > midnightToday.getTime()) {
             // Today, January 1st 00:00
@@ -105,7 +120,7 @@ public class StoryUtils {
     }
 
     private static SimpleDateFormat getTimeFormat(Context context) {
-        if (DateFormat.is24HourFormat(context)) {
+        if (android.text.format.DateFormat.is24HourFormat(context)) {
             return twentyFourHourFormat.get();
         } else {
             return twelveHourFormat.get();
@@ -133,6 +148,17 @@ public class StoryUtils {
         Date midnightYesterday = midnightYesterday();
 
         SimpleDateFormat timeFormat = getTimeFormat(context);
+
+        Locale locale = context.getResources().getConfiguration().locale;
+
+        if(!locale.getLanguage().equals("en")){
+            if (storyDate.getTime() > midnightToday.getTime()) {
+                return timeFormat.format(storyDate);
+            }else {
+                String pattern = android.text.format.DateFormat.getBestDateTimePattern(locale, "d MMM yyyy " + timeFormat.toPattern());
+                return DateFormat.format(pattern, storyDate).toString();
+            }
+        }
 
         if (storyDate.getTime() > midnightToday.getTime()) {
             // 00:00


### PR DESCRIPTION
Fixes #1217 

For non-english languages, "today" and "yesterday" are non included for simplicity, since we don't have translation infrastructure in place beyond system provided formatting