### PR TITLE
Fix menu text being too dark on Moto devices

### DIFF
--- a/clients/android/NewsBlur/res/values/styles.xml
+++ b/clients/android/NewsBlur/res/values/styles.xml
@@ -386,4 +386,12 @@
     <style name="contextPopupStyle.dark" parent="@android:style/Widget.Holo.PopupMenu">
         <item name="android:overlapAnchor">true</item>
     </style>
+
+    <!-- Fixes menu text being too dark on Moto devices -->
+    <style name="itemTextAppearance">
+        <item name="android:textColor">@color/black</item>
+    </style>
+    <style name="itemTextAppearance.dark">
+        <item name="android:textColor">@color/white</item>
+    </style>
 </resources>

--- a/clients/android/NewsBlur/res/values/theme.xml
+++ b/clients/android/NewsBlur/res/values/theme.xml
@@ -88,6 +88,7 @@
         <!--requires API 24-->
         <item name="android:contextPopupMenuStyle">@style/contextPopupStyle.dark</item>
         <item name="android:textColorPrimary">@color/white</item>
+        <item name="android:itemTextAppearance">@style/itemTextAppearance.dark</item>
     </style>
 
     <style name="NewsBlurBlackTheme" parent="@android:style/Theme.Holo" >
@@ -132,5 +133,6 @@
         <item name="muteicon">@style/muteicon.dark</item>
         <item name="android:contextPopupMenuStyle">@style/contextPopupStyle.dark</item>
         <item name="android:textColorPrimary">@color/white</item>
+        <item name="android:itemTextAppearance">@style/itemTextAppearance.dark</item>
     </style>
 </resources>


### PR DESCRIPTION
@caleb-allen this fixes #1145 - the menu text being too dark on Moto devices.

I don't have any other device types to test on so it has only been verified on my Moto G6.