### PR TITLE
modify css to not overflow images on chromium webview

### DIFF
--- a/clients/android/NewsBlur/assets/reading.css
+++ b/clients/android/NewsBlur/assets/reading.css
@@ -34,10 +34,10 @@ p, a, table, video, embed, object, iframe, div, figure, dl, dt, center {
 img {
     /* in addition to the tweaks for other media, set image height to auto, so aspect ratios are correct */
 	width: auto !important;
-    max-width: 100% !important;
+    max-width: 99% !important;
     height: auto !important;
     max-height: none !important;
-    margin: 0px !important;
+    margin: 1px !important;
 }
 
 p {


### PR DESCRIPTION
I think what was happening is that when a page loaded with a lot of content, the css styling could use sibling items to place images.

When an image alone was loaded, its width was being pushed outside the bounds of the parent by a single pixel, and the overflow style was to hide it.

This shifts the image to fit within the parent bounds.