### PR TITLE
Add Edge as a browser option

### DIFF
--- a/clients/ios/Classes/NewsBlurAppDelegate.m
+++ b/clients/ios/Classes/NewsBlurAppDelegate.m
@@ -2070,6 +2070,17 @@
         NSString *encodedURL = [url.absoluteString stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLHostAllowedCharacterSet]];
         NSString *firefoxURL = [NSString stringWithFormat:@"%@%@", @"firefox://open-url?url=", encodedURL];
         [[UIApplication sharedApplication] openURL:[NSURL URLWithString:firefoxURL] options:@{} completionHandler:nil];
+    } else if ([storyBrowser isEqualToString:@"edge"]){
+        NSString *edgeURL;
+        NSRange prefix = [[url absoluteString] rangeOfString: @"http"];
+        
+        if (NSNotFound != prefix.location) {
+            edgeURL = [[url absoluteString]
+                        stringByReplacingCharactersInRange: prefix
+                        withString: @"microsoft-edge-http"];
+        }
+        
+        [[UIApplication sharedApplication] openURL:[NSURL URLWithString:edgeURL] options:@{} completionHandler:nil];
     } else if ([storyBrowser isEqualToString:@"inappsafari"]) {
         [self showSafariViewControllerWithURL:url useReader:NO];
     } else if ([storyBrowser isEqualToString:@"inappsafarireader"]) {

--- a/clients/ios/Resources/Settings.bundle/Root.plist
+++ b/clients/ios/Resources/Settings.bundle/Root.plist
@@ -726,6 +726,7 @@
 				<string>Chrome</string>
 				<string>Opera Mini</string>
 				<string>Firefox</string>
+				<string>Edge</string>
 			</array>
 			<key>DefaultValue</key>
 			<string>inappsafari</string>
@@ -738,6 +739,7 @@
 				<string>chrome</string>
 				<string>opera_mini</string>
 				<string>firefox</string>
+				<string>edge</string>
 			</array>
 			<key>Key</key>
 			<string>story_browser</string>

--- a/clients/ios/Resources/Settings.bundle/Root~ipad.plist
+++ b/clients/ios/Resources/Settings.bundle/Root~ipad.plist
@@ -746,6 +746,7 @@
 				<string>Chrome</string>
 				<string>Opera Mini</string>
 				<string>Firefox</string>
+				<string>Edge</string>
 			</array>
 			<key>DefaultValue</key>
 			<string>inappsafari</string>
@@ -758,6 +759,7 @@
 				<string>chrome</string>
 				<string>opera_mini</string>
 				<string>firefox</string>
+				<string>edge</string>
 			</array>
 			<key>Key</key>
 			<string>story_browser</string>


### PR DESCRIPTION
This adds the option to use Microsoft Edge as the default browser in the iOS app, and is based on the existing logic for using the Opera browser.