### PR TITLE
Makefile: specify SHELL bash

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,4 @@
+SHELL := /bin/bash
 newsblur := $(shell docker ps -qf "name=newsblur_web")
 CURRENT_UID := $(shell id -u)
 CURRENT_GID := $(shell id -g)


### PR DESCRIPTION
Without it I get an error:
/bin/sh: 1: [[: not found
Which is ignored due to using leading dash `-` at https://github.com/samuelclay/NewsBlur/blob/3ad5295a33bb6fd469f8a64f0da6094656ad2da1/Makefile#L16

The same issue exists also in docker_django3.0