### PR TITLE
Move WebSub callbacks to HTTPS

### DIFF
--- a/apps/push/models.py
+++ b/apps/push/models.py
@@ -49,7 +49,7 @@ class PushSubscriptionManager(models.Manager):
             #     raise TypeError('callback cannot be None if there is not a reverable URL')
             # else:
             #     # callback = 'http://' + Site.objects.get_current() + callback_path
-            callback = "http://push.newsblur.com/push/%s" % subscription.pk # + callback_path
+            callback = "https://push.newsblur.com/push/%s" % subscription.pk # + callback_path
 
         try:
             response = self._send_request(hub, {


### PR DESCRIPTION
The HTTP endpoint just redirects to HTTPS anyway, so let’s skip a redirect (clients may not even implement it?) and protect the integrity of the payload.