### PR TITLE
fix YouTube video duration calculation

### DIFF
--- a/utils/feed_fetcher.py
+++ b/utils/feed_fetcher.py
@@ -326,15 +326,12 @@ class FetchFeed:
             if not thumbnail:
                 thumbnail = video['snippet']['thumbnails'].get('medium')
             duration_sec = isodate.parse_duration(video['contentDetails']['duration']).seconds
-            if duration_sec >= 3600:
-                hours = (duration_sec / 3600)
-                minutes = (duration_sec - (hours*3600)) / 60
-                seconds = duration_sec - (hours*3600) - (minutes*60)
-                duration = "%s:%s:%s" % (hours, '{0:02d}'.format(round(minutes)), '{0:02d}'.format(round(seconds)))
+            duration_min, seconds = divmod(duration_sec, 60)
+            hours, minutes = divmod(duration_min, 60)
+            if hours >= 1:
+                duration = "%s:%s:%s" % (hours, '{0:02d}'.format(minutes), '{0:02d}'.format(seconds))
             else:
-                minutes = duration_sec / 60
-                seconds = duration_sec - (minutes*60)
-                duration = "%s:%s" % ('{0:02d}'.format(round(minutes)), '{0:02d}'.format(round(seconds)))
+                duration = "%s:%s" % (minutes, '{0:02d}'.format(seconds))
             content = """<div class="NB-youtube-player">
                             <iframe allowfullscreen="true" src="%s?iv_load_policy=3"></iframe>
                          </div>


### PR DESCRIPTION
The current implementation does not play well with longer durations than 60 seconds because the results of the divisions to obtain hours and minutes aren't floored before being multiplied.

Example:
- 3679 seconds is converted to '1.0219444444444445:00:00' instead of '1:01:19'
- I believe this is linked to [this forum topic](https://forum.newsblur.com/t/youtube-video-length/8860)