### PR TITLE
fix save_story endpoint

### DIFF
--- a/apps/api/views.py
+++ b/apps/api/views.py
@@ -410,7 +410,7 @@ def save_story(request, token=None):
     message   = None
     profile   = None
     
-    if request.user.is_authenticated():
+    if request.user.is_authenticated:
         profile = request.user.profile
     else:
         try:


### PR DESCRIPTION
I got the following error when trying to save a story using the bookmarklet:
```
[Aug 27 05:16:33] Internal Server Error: /api/save_story/b76604da989d
Traceback (most recent call last):
  File "/usr/local/lib/python3.9/site-packages/django/core/handlers/exception.py", line 47, in inner
    response = get_response(request)
  File "/usr/local/lib/python3.9/site-packages/django/core/handlers/base.py", line 181, in _get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
  File "/usr/local/lib/python3.9/site-packages/sentry_sdk/integrations/django/views.py", line 67, in sentry_wrapped_callback
    return callback(request, *args, **kwargs)
  File "/srv/newsblur/utils/view_functions.py", line 54, in wrapper
    return self.view_wrapper(request, fn, *args, **kwargs)
  File "/srv/newsblur/utils/view_functions.py", line 82, in view_wrapper
    return fn(request, *args, **kwargs)
  File "/srv/newsblur/apps/api/views.py", line 413, in save_story
    if request.user.is_authenticated():
TypeError: 'bool' object is not callable
```