### PR TITLE
Fix strict JS error during folder moves

### DIFF
--- a/media/js/newsblur/reader/reader.js
+++ b/media/js/newsblur/reader/reader.js
@@ -4435,8 +4435,8 @@
                 $add.html($folders);
                 $save.addClass("NB-disabled").attr('disabled', "disabled").text('Select folders');
             } else {
-                folder_view = NEWSBLUR.assets.folders.get_view($feed) ||
-                              this.active_folder.folder_view;
+                var folder_view = NEWSBLUR.assets.folders.get_view($feed) ||
+                                  this.active_folder.folder_view;
                 var in_folder = folder_view.collection.options.title;
             }
             


### PR DESCRIPTION
At the moment on the live site, folder moves produce the console error `Uncaught ReferenceError: assignment to undeclared variable folder_view`. This change repairs folder moves to work in strict mode.