### PR TITLE
fixes issues with subdomain hosting of user blurblogs

### DIFF
--- a/apps/reader/views.py
+++ b/apps/reader/views.py
@@ -86,7 +86,7 @@ ALLOWED_SUBDOMAINS = [
 
 def get_subdomain(request):
     host = request.META.get('HTTP_HOST')
-    if host and host.count(".") == 2:
+    if host and host.count(".") >= 2:
         return host.split(".")[0]
     else:
         return None


### PR DESCRIPTION
This is a super simple fix for the problem I outlined in [this forum post](https://forum.newsblur.com/t/what-is-the-container-endpoint-middleware-used-to-connec-to-the-public-blurblog/9783). Instead of looking at the current host and checking to see if there is exactly 2 periods.. I am saying if there are 2 or more then just return the first split is presumed to be the sub (maybe sub sub) domain that we care about. 

It works for me with the NewsBlur being served at `news.mydomain.com`, but I could imagine this working with even more nested sub domains.. ¯\_(ツ)_/¯

