### PR TITLE
Add Apple App Store badge to the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@
 <a href="https://play.google.com/store/apps/details?id=com.newsblur" target="_blank">
 <img src="https://play.google.com/intl/en_us/badges/images/generic/en-play-badge.png" alt="Get it on Google Play" height="80"/></a>
 
+&nbsp;&nbsp;&nbsp;<a href="https://apps.apple.com/us/app/newsblur/id463981119"><img src="https://tools.applemediaservices.com/api/badges/download-on-the-app-store/black/en-us?size=250x83" alt="Download on the Apple App Store" height="55"></a>
+
 ## Features
 
  1. Shows the original site (you have to see it to believe it).


### PR DESCRIPTION
Hello,

I am a happy long time user of the iOS NewsBlur application. I wanted to add the Apple App Store badge to the `README.md` so that others know you can use NewsBlur on Apple mobile devices too.

Below is from the commit message
---

- Add a clickable badge for the NewsBlur Apple App Store page

- Use Apple's marketing website tool to get the App Store badge
  - https://tools.applemediaservices.com/app/463981119

- Used HTML elements `&nbsp;` to add left padding to the Apple badge so that it aligns with the F-Droid badge. GitHub restricts what kind of inline styling is allowed in the README.md for security reasons. Inline styling of padding left is one of those attributes that get removed.
  - https://github.com/github/markup#github-markup