### PR TITLE
Fix not forcing Android clients to use `refresh_feeds`

### DIFF
--- a/apps/reader/views.py
+++ b/apps/reader/views.py
@@ -337,7 +337,7 @@ def load_feeds(request):
         return load_feeds_flat(request)
 
     platform = extract_user_agent(request)
-    if platform in ["iPhone", "iPad", "Androd"]:
+    if platform in ["iPhone", "iPad", "Android"]:
         # Remove this check once the iOS and Android updates go out which have update_counts=False
         # and then guarantee a refresh_feeds call
         update_counts = False


### PR DESCRIPTION
This patches a long outstanding bug in 50e88b2bafd8b183b364484b57d3ed455db7b27a.