### PR TITLE
Remove mobile check for update_counts

### DIFF
--- a/apps/reader/views.py
+++ b/apps/reader/views.py
@@ -101,7 +101,7 @@ from utils.story_functions import (
     format_story_link_date__short,
     strip_tags,
 )
-from utils.user_functions import ajax_login_required, extract_user_agent, get_user
+from utils.user_functions import ajax_login_required, get_user
 from utils.view_functions import (
     get_argument_or_404,
     is_true,
@@ -335,12 +335,6 @@ def load_feeds(request):
 
     if flat:
         return load_feeds_flat(request)
-
-    platform = extract_user_agent(request)
-    if platform in ["iPhone", "iPad", "Androd"]:
-        # Remove this check once the iOS and Android updates go out which have update_counts=False
-        # and then guarantee a refresh_feeds call
-        update_counts = False
 
     try:
         folders = UserSubscriptionFolders.objects.get(user=user)


### PR DESCRIPTION
This check was added four years ago in .50e88b2bafd8b183b364484b57d3ed455db7b27a. The expectation was that the mobile clients would be migrated to using a combination of load_feeds and refresh_feeds. However, due to a typo, this check was only applied to Apple (iPad, iOS) clients. In the interim, we've ended up in the following situation:

- The iOS client uses refresh_feeds, as it has for 12 years since 09affc6ccf49e5520a90a623412e28a829666270
- The Android client uses load_feeds with update_counts=True, as it has been allowed to get away with for years...

Let's bring back equality for iOS clients!