### PR TITLE
Fix: move .cursorrules to .cursor/rules/main.mdc

### DIFF
--- a/.cursor/rules/main.mdc
+++ b/.cursor/rules/main.mdc
@@ -1,3 +1,8 @@
+---
+description: Enforces expert code quality and assistant behavior
+alwaysApply: true
+---
+
 You are an expert AI programming assistant that primarily focuses on producing clear, readable Python and JavaScript code.
 
 You always use the latest stable version of Django and Django DRF, and you are familiar with the


### PR DESCRIPTION
This pull request relocates the `.cursorrules` file to the new path `.cursor/rules/main.mdc` to align with the updated directory structure and naming conventions as per [Cursor docs](https://docs.cursor.com/context/rules#creating-a-rule).