### PR TITLE
Don't prepend `https://` to newsletters' anchor links.

### DIFF
--- a/utils/scrubber/__init__.py
+++ b/utils/scrubber/__init__.py
@@ -297,7 +297,7 @@ class Scrubber(object):
 
     def _clean_path(self, node, attrname):
         url = node.get(attrname)
-        if url and "://" not in url and not url.startswith("mailto:"):
+        if url and "://" not in url and not url.startswith("mailto:") and not url.startswith("#"):
             print(url)
             if url[0] not in ("/", ".") and not self.base_url:
                 node[attrname] = "http://" + url


### PR DESCRIPTION
Currently any anchor links like `#footnote` in newsletters' HTML gets `https://` prepended, leading to `https://#footnote`, which is wrong. This fixes it by keeping them as-is.