### PR TITLE
Allow `id=` attributes in the scrubber.

### DIFF
--- a/utils/scrubber/__init__.py
+++ b/utils/scrubber/__init__.py
@@ -184,6 +184,7 @@ class Scrubber(object):
             "dir",
             "height",
             "href",
+            "id",
             "src",
             "style",
             "title",


### PR DESCRIPTION
Without it anchor links in newsletters won't work.