### PR TITLE
Fix Android app making repeated requests for the same feed page

### DIFF
--- a/clients/android/NewsBlur/app/src/main/java/com/newsblur/database/BlurDatabaseHelper.java
+++ b/clients/android/NewsBlur/app/src/main/java/com/newsblur/database/BlurDatabaseHelper.java
@@ -453,27 +453,35 @@ public class BlurDatabaseHelper {
         ContentValues values = story.getValues();
         dbRW.insertWithOnConflict(DatabaseConstants.STORY_TABLE, null, values, SQLiteDatabase.CONFLICT_REPLACE);
         // if a story was shared by a user, also insert it into the social table under their userid, too
-        for (String sharedUserId : story.sharedUserIds) {
-            ContentValues socialValues = new ContentValues();
-            socialValues.put(DatabaseConstants.SOCIALFEED_STORY_USER_ID, sharedUserId);
-            socialValues.put(DatabaseConstants.SOCIALFEED_STORY_STORYID, values.getAsString(DatabaseConstants.STORY_ID));
-            dbRW.insertWithOnConflict(DatabaseConstants.SOCIALFEED_STORY_MAP_TABLE, null, socialValues, SQLiteDatabase.CONFLICT_REPLACE);
+        if (story.sharedUserIds != null) {
+            for (String sharedUserId : story.sharedUserIds) {
+                ContentValues socialValues = new ContentValues();
+                socialValues.put(DatabaseConstants.SOCIALFEED_STORY_USER_ID, sharedUserId);
+                socialValues.put(DatabaseConstants.SOCIALFEED_STORY_STORYID, values.getAsString(DatabaseConstants.STORY_ID));
+                dbRW.insertWithOnConflict(DatabaseConstants.SOCIALFEED_STORY_MAP_TABLE, null, socialValues, SQLiteDatabase.CONFLICT_REPLACE);
+            }
         }
         // handle comments
-        for (Comment comment : story.publicComments) {
-            comment.storyId = story.id;
-            insertSingleCommentExtSync(comment);
+        if (story.publicComments != null) {
+            for (Comment comment : story.publicComments) {
+                comment.storyId = story.id;
+                insertSingleCommentExtSync(comment);
+            }
         }
-        for (Comment comment : story.friendsComments) {
-            comment.storyId = story.id;
-            comment.byFriend = true;
-            insertSingleCommentExtSync(comment);
+        if (story.friendsComments != null) {
+            for (Comment comment : story.friendsComments) {
+                comment.storyId = story.id;
+                comment.byFriend = true;
+                insertSingleCommentExtSync(comment);
+            }
         }
-        for (Comment comment : story.friendsShares) {
-            comment.isPseudo = true;
-            comment.storyId = story.id;
-            comment.byFriend = true;
-            insertSingleCommentExtSync(comment);
+        if (story.friendsShares != null) {
+            for (Comment comment : story.friendsShares) {
+                comment.isPseudo = true;
+                comment.storyId = story.id;
+                comment.byFriend = true;
+                insertSingleCommentExtSync(comment);
+            }
         }
     }
 

--- a/clients/android/NewsBlur/app/src/main/java/com/newsblur/domain/Story.java
+++ b/clients/android/NewsBlur/app/src/main/java/com/newsblur/domain/Story.java
@@ -134,8 +134,9 @@ public class Story implements Serializable {
 
 	public ContentValues getValues() {
 		final ContentValues values = new ContentValues();
+        String safeTitle = title == null ? "" : title;
 		values.put(DatabaseConstants.STORY_ID, id);
-		values.put(DatabaseConstants.STORY_TITLE, title.replace("\n", " ").replace("\r", " "));
+		values.put(DatabaseConstants.STORY_TITLE, safeTitle.replace("\n", " ").replace("\r", " "));
 		values.put(DatabaseConstants.STORY_TIMESTAMP, timestamp);
         values.put(DatabaseConstants.STORY_CONTENT, content);
         values.put(DatabaseConstants.STORY_SHORT_CONTENT, shortContent);
@@ -316,21 +317,23 @@ public class Story implements Serializable {
         String content = story.content;
         
         String ytUrl = null;
-        if (ytUrl == null) {
-            Matcher m = ytSniff1.matcher(content);
-            if (m.find()) ytUrl = m.group(1);
-        }
-        if (ytUrl == null) {
-            Matcher m = ytSniff2.matcher(content);
-            if (m.find()) ytUrl = m.group(1);
-        }
-        if (ytUrl == null) {
-            Matcher m = ytSniff3.matcher(content);
-            if (m.find()) ytUrl = m.group(1);
-        }
-        if (ytUrl == null) {
-            Matcher m = ytSniff4.matcher(content);
-            if (m.find()) ytUrl = m.group(1);
+        if (content != null && !content.isEmpty()) {
+            if (ytUrl == null) {
+                Matcher m = ytSniff1.matcher(content);
+                if (m.find()) ytUrl = m.group(1);
+            }
+            if (ytUrl == null) {
+                Matcher m = ytSniff2.matcher(content);
+                if (m.find()) ytUrl = m.group(1);
+            }
+            if (ytUrl == null) {
+                Matcher m = ytSniff3.matcher(content);
+                if (m.find()) ytUrl = m.group(1);
+            }
+            if (ytUrl == null) {
+                Matcher m = ytSniff4.matcher(content);
+                if (m.find()) ytUrl = m.group(1);
+            }
         }
         if (ytUrl != null) {
             return YT_THUMB_PRE + ytUrl + YT_THUMB_POST;

--- a/clients/android/NewsBlur/app/src/main/java/com/newsblur/serialization/StoryTypeAdapter.java
+++ b/clients/android/NewsBlur/app/src/main/java/com/newsblur/serialization/StoryTypeAdapter.java
@@ -8,6 +8,7 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonParseException;
 
 import com.newsblur.NbApplication;
+import com.newsblur.domain.Comment;
 import com.newsblur.domain.Story;
 import com.newsblur.network.APIConstants;
 import com.newsblur.util.StoryUtil;
@@ -40,6 +41,16 @@ public class StoryTypeAdapter implements JsonDeserializer<Story> {
     @Override
     public Story deserialize(JsonElement jsonElement, Type type, JsonDeserializationContext jsonDeserializationContext) throws JsonParseException {
         Story story = gson.fromJson(jsonElement, Story.class);
+        if (story.content == null) story.content = "";
+        if (story.title == null) story.title = "";
+        if (story.sharedUserIds == null) story.sharedUserIds = new String[]{};
+        if (story.friendUserIds == null) story.friendUserIds = new String[]{};
+        if (story.tags == null) story.tags = new String[]{};
+        if (story.userTags == null) story.userTags = new String[]{};
+        if (story.publicComments == null) story.publicComments = new Comment[]{};
+        if (story.friendsComments == null) story.friendsComments = new Comment[]{};
+        if (story.friendsShares == null) story.friendsShares = new Comment[]{};
+        if (story.imageUrls == null) story.imageUrls = new String[]{};
 
         // Convert story_timestamp to milliseconds
         story.timestamp = story.timestamp * 1000;


### PR DESCRIPTION
## Summary

- Fixes null pointer exceptions in Android story deserialization and insertion that caused the sync service to repeatedly request the same feed page
- When `insertStory()` failed due to null fields, `FeedPagesSeen` wasn't updated, causing infinite retry loops for the same page

## Changes

- **StoryTypeAdapter**: Initialize all array fields to empty arrays after deserialization
- **Story.getValues()**: Handle null title safely  
- **Story.extractYoutubeId()**: Check for null/empty content before regex matching
- **BlurDatabaseHelper.insertStory()**: Add null checks before iterating over `sharedUserIds`, `publicComments`, `friendsComments`, and `friendsShares`

## Root Cause

Server logs showed a user repeatedly loading the same feed page (p30) dozens of times per second:
```
[happ-web-01] [androd] [flagpirate] Loading feed: DER SPIEGEL - Schlagze/p30 (newest/all)
[happ-web-02] [androd] [flagpirate] Loading feed: DER SPIEGEL - Schlagze/p30 (newest/all)
[happ-web-05] [androd] [flagpirate] Loading feed: DER SPIEGEL - Schlagze/p30 (newest/all)
...
```

The issue was that `NBSyncService.syncPendingFeedStories()` only updates `FeedPagesSeen` after `insertStories()` completes successfully. If null fields caused an NPE, the page counter never advanced.

## Test plan

- [ ] Verify Android app no longer makes repeated requests for the same page
- [ ] Test feeds with stories that may have null comments/shares fields
- [ ] Confirm story insertion works correctly with null-safe code

🤖 Generated with [Claude Code](https://claude.com/claude-code)