### PR TITLE
Add active reading time tracking on Android

### DIFF
--- a/clients/android/NewsBlur/app/src/main/java/com/newsblur/NbApplication.kt
+++ b/clients/android/NewsBlur/app/src/main/java/com/newsblur/NbApplication.kt
@@ -14,6 +14,7 @@ import com.newsblur.di.ThumbnailCache
 import com.newsblur.preference.PrefsRepo
 import com.newsblur.util.FileCache
 import com.newsblur.util.Log
+import com.newsblur.util.ReadTimeTracker
 import dagger.hilt.android.HiltAndroidApp
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -42,6 +43,9 @@ class NbApplication :
 
     @Inject
     lateinit var dbHelper: Provider<BlurDatabaseHelper>
+
+    @Inject
+    lateinit var readTimeTracker: Provider<ReadTimeTracker>
 
     override fun onCreate() {
         super<Application>.onCreate()
@@ -86,11 +90,15 @@ class NbApplication :
     override fun onStart(owner: LifecycleOwner) {
         super.onStart(owner)
         isAppForeground = true
+        readTimeTracker.get().isAppActive = true
+        readTimeTracker.get().resumeFromBackground()
     }
 
     override fun onStop(owner: LifecycleOwner) {
         super.onStop(owner)
         isAppForeground = false
+        readTimeTracker.get().isAppActive = false
+        readTimeTracker.get().harvestForBackground()
     }
 
     companion object {

--- a/clients/android/NewsBlur/app/src/main/java/com/newsblur/di/NetworkModule.kt
+++ b/clients/android/NewsBlur/app/src/main/java/com/newsblur/di/NetworkModule.kt
@@ -32,6 +32,7 @@ import com.newsblur.util.AppConstants.READING_IMAGES_PATH
 import com.newsblur.util.AppConstants.READING_RES_PATH
 import com.newsblur.util.FileCache
 import com.newsblur.util.NetworkUtils
+import com.newsblur.util.ReadTimeTracker
 import com.newsblur.web.WebImagesPathHandler
 import dagger.Module
 import dagger.Provides
@@ -132,10 +133,16 @@ object NetworkModule {
 
     @Singleton
     @Provides
+    fun provideReadTimeTracker(networkClient: NetworkClient): ReadTimeTracker =
+        ReadTimeTracker(networkClient)
+
+    @Singleton
+    @Provides
     fun provideStoryApi(
         gson: Gson,
         networkClient: NetworkClient,
-    ): StoryApi = StoryApiImpl(gson, networkClient)
+        readTimeTracker: ReadTimeTracker,
+    ): StoryApi = StoryApiImpl(gson, networkClient, readTimeTracker)
 
     @Singleton
     @Provides

--- a/clients/android/NewsBlur/app/src/main/java/com/newsblur/network/APIConstants.java
+++ b/clients/android/NewsBlur/app/src/main/java/com/newsblur/network/APIConstants.java
@@ -146,6 +146,7 @@ public class APIConstants {
     public static final String PARAMETER_ORDER_ID = "order_id";
     public static final String PARAMETER_PRODUCT_ID = "product_id";
     public static final String PARAMETER_SHOW_CHANGES = "show_changes";
+    public static final String PARAMETER_READ_TIMES = "read_times";
 
     public static final String VALUE_PREFIX_SOCIAL = "social:";
     public static final String VALUE_ALLSOCIAL = "river:blurblogs"; // the magic value passed to the mark-read API for all social feeds

--- a/clients/android/NewsBlur/app/src/main/java/com/newsblur/util/ReadTimeTracker.kt
+++ b/clients/android/NewsBlur/app/src/main/java/com/newsblur/util/ReadTimeTracker.kt
@@ -1,0 +1,158 @@
+package com.newsblur.util
+
+import com.newsblur.network.APIConstants
+import com.newsblur.network.NetworkClient
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import org.json.JSONObject
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class ReadTimeTracker @Inject constructor(
+    private val networkClient: NetworkClient,
+) {
+    var currentStoryHash: String? = null
+        private set
+
+    // Hash saved across background transitions so tracking can resume on foreground
+    private var backgroundedStoryHash: String? = null
+
+    private val readTimes = mutableMapOf<String, Int>()
+    private val queuedReadTimes = mutableMapOf<String, Int>()
+    private var lastActivityMs: Long = 0L
+    var isAppActive: Boolean = true
+    private var timerJob: Job? = null
+
+    fun startTracking(storyHash: String) {
+        stopTracking()
+        synchronized(this) {
+            currentStoryHash = storyHash
+            lastActivityMs = System.currentTimeMillis()
+        }
+        timerJob = CoroutineScope(Dispatchers.Default).launch {
+            while (isActive) {
+                delay(1000)
+                synchronized(this@ReadTimeTracker) {
+                    val hash = currentStoryHash ?: return@synchronized
+                    if (!isAppActive) return@synchronized
+                    if (System.currentTimeMillis() - lastActivityMs < IDLE_THRESHOLD_MS) {
+                        readTimes[hash] = (readTimes[hash] ?: 0) + 1
+                    }
+                }
+            }
+        }
+    }
+
+    fun stopTracking() {
+        timerJob?.cancel()
+        timerJob = null
+        synchronized(this) {
+            currentStoryHash = null
+        }
+    }
+
+    fun recordActivity() {
+        synchronized(this) {
+            lastActivityMs = System.currentTimeMillis()
+        }
+    }
+
+    fun getAndResetReadTime(storyHash: String): Int {
+        synchronized(this) {
+            return readTimes.remove(storyHash) ?: 0
+        }
+    }
+
+    fun queueReadTime(storyHash: String, seconds: Int) {
+        synchronized(this) {
+            queuedReadTimes[storyHash] = (queuedReadTimes[storyHash] ?: 0) + seconds
+        }
+    }
+
+    fun consumeQueuedReadTimesJSON(): String? {
+        synchronized(this) {
+            if (queuedReadTimes.isEmpty()) return null
+            val json = JSONObject(queuedReadTimes.mapValues { it.value } as Map<*, *>).toString()
+            queuedReadTimes.clear()
+            return json
+        }
+    }
+
+    fun restoreQueuedReadTimes(json: String) {
+        synchronized(this) {
+            val obj = JSONObject(json)
+            for (key in obj.keys()) {
+                queuedReadTimes[key] = (queuedReadTimes[key] ?: 0) + obj.getInt(key)
+            }
+        }
+    }
+
+    fun harvestAndFlush() {
+        synchronized(this) {
+            currentStoryHash?.let { hash ->
+                val seconds = readTimes.remove(hash) ?: 0
+                if (seconds > 0) {
+                    queuedReadTimes[hash] = (queuedReadTimes[hash] ?: 0) + seconds
+                }
+            }
+        }
+        stopTracking()
+        flushReadTimes()
+    }
+
+    /**
+     * Harvest accumulated time and flush, but remember which story was being
+     * tracked so [resumeFromBackground] can restart the timer.
+     */
+    fun harvestForBackground() {
+        synchronized(this) {
+            backgroundedStoryHash = currentStoryHash
+        }
+        harvestAndFlush()
+    }
+
+    /**
+     * Restart tracking for the story that was active when the app went to background.
+     */
+    fun resumeFromBackground() {
+        val hash: String?
+        synchronized(this) {
+            hash = backgroundedStoryHash
+            backgroundedStoryHash = null
+        }
+        hash?.let { startTracking(it) }
+    }
+
+    private fun flushReadTimes() {
+        val json: String
+        synchronized(this) {
+            if (queuedReadTimes.isEmpty()) return
+            json = JSONObject(queuedReadTimes.mapValues { it.value } as Map<*, *>).toString()
+            queuedReadTimes.clear()
+        }
+        CoroutineScope(Dispatchers.IO).launch {
+            try {
+                val values = com.newsblur.domain.ValueMultimap()
+                values.put(APIConstants.PARAMETER_READ_TIMES, json)
+                val urlString = APIConstants.buildUrl(APIConstants.PATH_MARK_STORIES_READ)
+                val response = networkClient.post(urlString, values)
+                if (response.isError) {
+                    Log.w(this@ReadTimeTracker, "Flush read times API error, restoring")
+                    restoreQueuedReadTimes(json)
+                }
+            } catch (e: Exception) {
+                Log.e(this@ReadTimeTracker, "Failed to flush read times", e)
+                restoreQueuedReadTimes(json)
+            }
+        }
+    }
+
+    companion object {
+        private const val IDLE_THRESHOLD_MS = 120_000L
+    }
+}


### PR DESCRIPTION
## Summary
- Add `ReadTimeTracker` Hilt singleton that tracks active reading seconds per story using a 1-second coroutine timer with a 2-minute idle threshold (matching iOS/web behavior)
- Piggyback `read_times` JSON on `mark_story_hashes_as_read` API calls in `StoryApiImpl`, with restore-on-failure for both API errors and exceptions
- Hook into `Reading.kt` (page transitions, scroll activity, finish) and `NbApplication.kt` (app background/foreground lifecycle) to harvest and flush accumulated read times

## Test plan
- [ ] Open a story, read for 10+ seconds, swipe to next story — verify `read_times` JSON appears in the `mark_story_hashes_as_read` POST
- [ ] Open a story, read, press back to feed list — verify standalone POST with `read_times` is sent
- [ ] Open a story, background the app, return — verify accumulated time is flushed on background and tracking resumes on foreground
- [ ] Rapid swiping through stories — verify no crash, accumulated times are small/zero
- [ ] Open story, idle 2+ min, scroll again — verify time resumes from pause (not reset)
- [ ] Network failure — verify read times are restored to queue and sent on next successful call

---
Generated with [Claude Code](https://claude.com/claude-code)