### PR TITLE
Fix black formatting lint errors in briefing module

### DIFF
--- a/apps/briefing/scoring.py
+++ b/apps/briefing/scoring.py
@@ -334,8 +334,7 @@ def select_briefing_stories(
             if not keywords:
                 continue
             logging.debug(
-                " ---> Briefing scoring: %s keywords=%s (from prompt: %s)"
-                % (custom_key, keywords, prompt)
+                " ---> Briefing scoring: %s keywords=%s (from prompt: %s)" % (custom_key, keywords, prompt)
             )
             reserved = 0
             for s in remaining:
@@ -360,9 +359,7 @@ def select_briefing_stories(
                     " ---> Briefing scoring: reserved %s stories for %s (%s)" % (reserved, custom_key, prompt)
                 )
             else:
-                logging.debug(
-                    " ---> Briefing scoring: no stories matched %s (%s)" % (custom_key, prompt)
-                )
+                logging.debug(" ---> Briefing scoring: no stories matched %s (%s)" % (custom_key, prompt))
 
     return result
 
@@ -407,7 +404,12 @@ def _find_duplicate_stories(candidates, stories_by_hash):
 
 
 def _get_classifier_matches(
-    story, classifier_feeds, classifier_authors, classifier_tags, classifier_titles, feed_title_map
+    story,
+    classifier_feeds,
+    classifier_authors,
+    classifier_tags,
+    classifier_titles,
+    feed_title_map,
 ):
     """Identify which classifiers matched positively for a story."""
     matches = []

--- a/apps/briefing/summary.py
+++ b/apps/briefing/summary.py
@@ -101,7 +101,10 @@ SECTION_PROMPTS = {
 
 
 def _build_system_prompt(
-    summary_length="medium", summary_style="bullets", sections=None, custom_section_prompts=None
+    summary_length="medium",
+    summary_style="bullets",
+    sections=None,
+    custom_section_prompts=None,
 ):
     """Build the system prompt based on user preferences for length, style, and sections."""
     from apps.briefing.models import DEFAULT_SECTIONS
@@ -123,7 +126,7 @@ def _build_system_prompt(
         custom_key = "custom_%d" % (i + 1)
         if active_sections.get(custom_key, False) and prompt:
             section_lines.append(
-                '%d. Keyword section (KEY: %s) — The reader has a keyword section that matches stories '
+                "%d. Keyword section (KEY: %s) — The reader has a keyword section that matches stories "
                 'with these keywords: "%s". Generate a section header based on the keywords. '
                 "ONLY include stories whose CATEGORY field is set to %s."
                 % (num, custom_key, prompt, custom_key)

--- a/apps/briefing/tests.py
+++ b/apps/briefing/tests.py
@@ -136,7 +136,12 @@ class BriefingTestCase(TestCase):
             story_content=content,
             story_author_name=author or "TestAuthor",
             story_permalink="http://test.com/%s" % title.replace(" ", "-").lower(),
-            story_guid="guid-%s-%s-%s" % (feed.pk, title.replace(" ", "-").lower(), BriefingTestCase._story_counter),
+            story_guid="guid-%s-%s-%s"
+            % (
+                feed.pk,
+                title.replace(" ", "-").lower(),
+                BriefingTestCase._story_counter,
+            ),
             story_tags=tags or [],
         )
         story.save()
@@ -416,7 +421,11 @@ class Test_Summary(TestCase):
                 "trending_global": [("h3", "S3")],
             }
         )
-        active = {"trending_unread": False, "long_read": False, "trending_global": False}
+        active = {
+            "trending_unread": False,
+            "long_read": False,
+            "trending_global": False,
+        }
         result = filter_disabled_sections(html, active)
         # tests.py: trending_global is always kept
         self.assertIn("trending_global", result)
@@ -748,7 +757,13 @@ class Test_Scoring(BriefingTestCase):
     def test_classifier_matches_multiple(self):
         cf = MClassifierFeed(user_id=self.user.pk, feed_id=self.feed.pk, social_user_id=0, score=1)
         cf.save()
-        ca = MClassifierAuthor(user_id=self.user.pk, author="Alice", feed_id=self.feed.pk, social_user_id=0, score=1)
+        ca = MClassifierAuthor(
+            user_id=self.user.pk,
+            author="Alice",
+            feed_id=self.feed.pk,
+            social_user_id=0,
+            score=1,
+        )
         ca.save()
         feed_title_map = {self.feed.pk: "Test Feed 1"}
         matches = _get_classifier_matches(self.stories[0], [cf], [ca], [], [], feed_title_map)
@@ -1703,7 +1718,10 @@ class Test_Tasks(BriefingTestCase):
                     with patch("apps.briefing.summary.embed_briefing_icons") as mock_ei:
                         mock_ei.return_value = "<div>S</div>"
                         with patch("apps.briefing.models.create_briefing_story") as mock_cs:
-                            mock_cs.return_value = (MagicMock(), MagicMock(story_hash="t:h"))
+                            mock_cs.return_value = (
+                                MagicMock(),
+                                MagicMock(story_hash="t:h"),
+                            )
                             GenerateUserBriefing(self.user.pk)
                             mock_summary.assert_called_once()
 


### PR DESCRIPTION
## Summary
- Apply isort and black formatting fixes to 3 files in `apps/briefing/`
- Fixes line-wrapping issues in `scoring.py`, `summary.py`, and `tests.py`
- Full lint suite (isort, black, flake8) passes clean

## Test plan
- [x] Verified `isort --profile black --check-only` passes
- [x] Verified `black --line-length 110 --check` passes
- [x] Verified `flake8` passes with zero errors
- [x] Full codebase lint check passes (491 files unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
*Automated by [nightshift](https://github.com/marcus/nightshift)*

<!-- nightshift:metadata
task-id: lint-fix:/Users/sclay/projects/newsblur
task-type: lint-fix
task-title: Linter Fixes
provider: claude
score: 4.2
cost-tier: Low (10-50k)
iterations: 1
duration: 6m37s
run-started: 2026-02-18T02:00:06-08:00
nightshift:metadata -->
