### PR TITLE
Fix Black formatting in briefing module

### DIFF
--- a/apps/briefing/scoring.py
+++ b/apps/briefing/scoring.py
@@ -334,8 +334,7 @@ def select_briefing_stories(
             if not keywords:
                 continue
             logging.debug(
-                " ---> Briefing scoring: %s keywords=%s (from prompt: %s)"
-                % (custom_key, keywords, prompt)
+                " ---> Briefing scoring: %s keywords=%s (from prompt: %s)" % (custom_key, keywords, prompt)
             )
             reserved = 0
             for s in remaining:
@@ -360,9 +359,7 @@ def select_briefing_stories(
                     " ---> Briefing scoring: reserved %s stories for %s (%s)" % (reserved, custom_key, prompt)
                 )
             else:
-                logging.debug(
-                    " ---> Briefing scoring: no stories matched %s (%s)" % (custom_key, prompt)
-                )
+                logging.debug(" ---> Briefing scoring: no stories matched %s (%s)" % (custom_key, prompt))
 
     return result
 

--- a/apps/briefing/summary.py
+++ b/apps/briefing/summary.py
@@ -123,7 +123,7 @@ def _build_system_prompt(
         custom_key = "custom_%d" % (i + 1)
         if active_sections.get(custom_key, False) and prompt:
             section_lines.append(
-                '%d. Keyword section (KEY: %s) — The reader has a keyword section that matches stories '
+                "%d. Keyword section (KEY: %s) — The reader has a keyword section that matches stories "
                 'with these keywords: "%s". Generate a section header based on the keywords. '
                 "ONLY include stories whose CATEGORY field is set to %s."
                 % (num, custom_key, prompt, custom_key)

--- a/apps/briefing/tests.py
+++ b/apps/briefing/tests.py
@@ -136,7 +136,8 @@ class BriefingTestCase(TestCase):
             story_content=content,
             story_author_name=author or "TestAuthor",
             story_permalink="http://test.com/%s" % title.replace(" ", "-").lower(),
-            story_guid="guid-%s-%s-%s" % (feed.pk, title.replace(" ", "-").lower(), BriefingTestCase._story_counter),
+            story_guid="guid-%s-%s-%s"
+            % (feed.pk, title.replace(" ", "-").lower(), BriefingTestCase._story_counter),
             story_tags=tags or [],
         )
         story.save()
@@ -748,7 +749,9 @@ class Test_Scoring(BriefingTestCase):
     def test_classifier_matches_multiple(self):
         cf = MClassifierFeed(user_id=self.user.pk, feed_id=self.feed.pk, social_user_id=0, score=1)
         cf.save()
-        ca = MClassifierAuthor(user_id=self.user.pk, author="Alice", feed_id=self.feed.pk, social_user_id=0, score=1)
+        ca = MClassifierAuthor(
+            user_id=self.user.pk, author="Alice", feed_id=self.feed.pk, social_user_id=0, score=1
+        )
         ca.save()
         feed_title_map = {self.feed.pk: "Test Feed 1"}
         matches = _get_classifier_matches(self.stories[0], [cf], [ca], [], [], feed_title_map)


### PR DESCRIPTION
## Summary
- Apply Black auto-formatting to `apps/briefing/scoring.py` (collapse short logging calls onto single lines)
- Apply Black auto-formatting to `apps/briefing/summary.py` (normalize quote style from single to double quotes)
- Apply Black auto-formatting to `apps/briefing/tests.py` (line-wrapping for long lines exceeding 110 chars)

All changes are purely cosmetic formatting — no behavioral changes.

## Test plan
- [x] `isort --check` passes
- [x] `black --check` passes
- [x] `flake8` passes (project config: E9,F63,F7,F82)
- [x] 97/98 briefing tests pass (1 pre-existing failure unrelated to formatting)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
*Automated by [nightshift](https://github.com/marcus/nightshift)*

<!-- nightshift:metadata
task-id: lint-fix:/Users/sclay/projects/newsblur
task-type: lint-fix
task-title: Linter Fixes
provider: claude
score: 4.1
cost-tier: Low (10-50k)
iterations: 1
duration: 4m57s
run-started: 2026-02-15T02:00:05-08:00
nightshift:metadata -->
