### PR TITLE
Fix Android code block rendering

### DIFF
--- a/clients/android/NewsBlur/app/src/main/assets/reading.css
+++ b/clients/android/NewsBlur/app/src/main/assets/reading.css
@@ -75,6 +75,10 @@ pre, blockquote {
     text-wrap: pretty;
 }
 
+pre {
+    white-space: pre-wrap !important;
+}
+
 figure.wp-block-embed,
 .wp-block-embed__wrapper,
 .embed-responsive {


### PR DESCRIPTION
## Summary
- Fixes code blocks (`<pre>` tags) appearing as a single garbled line on Android by overriding `white-space: normal` with `white-space: pre-wrap` for `<pre>` elements
- The shared `pre, blockquote` CSS rule was collapsing all whitespace, which is correct for blockquotes but destroys code formatting
- iOS doesn't have this issue because its CSS never overrides `white-space` on `<pre>` tags

## Test plan
- [ ] Open a feed with code blocks (e.g. [Applied Cartography feed 9922196](https://www.newsblur.com/site/9922196/applied-cartography), post: https://jmduke.com/posts/good-tests.html)
- [ ] Verify code blocks preserve newlines and indentation
- [ ] Verify long lines wrap at the container edge instead of scrolling horizontally
- [ ] Verify blockquotes still render normally

Fixes #2066

🤖 Generated with [Claude Code](https://claude.com/claude-code)