### PR TITLE
Add module-level docstrings to remaining views, models, and tasks

### DIFF
--- a/apps/analyzer/tasks.py
+++ b/apps/analyzer/tasks.py
@@ -1,3 +1,5 @@
+"""Analyzer tasks: email notifications for popularity query results."""
+
 from newsblur_web.celeryapp import app
 from utils import log as logging
 

--- a/apps/api/models.py
+++ b/apps/api/models.py
@@ -1,3 +1,3 @@
-from django.db import models
+"""API models: placeholder for the external REST API app."""
 
-# Create your models here.
+from django.db import models

--- a/apps/archive_extension/models.py
+++ b/apps/archive_extension/models.py
@@ -1,3 +1,5 @@
+"""Archive extension models: store archived web pages from the browser extension."""
+
 import hashlib
 import zlib
 from datetime import datetime

--- a/apps/ask_ai/tasks.py
+++ b/apps/ask_ai/tasks.py
@@ -1,3 +1,5 @@
+"""Ask AI tasks: process user questions via LLM providers and stream responses."""
+
 import json
 import time
 import uuid

--- a/apps/ask_ai/views.py
+++ b/apps/ask_ai/views.py
@@ -1,3 +1,5 @@
+"""Ask AI views: API endpoint for asking AI questions about stories."""
+
 import re
 import uuid
 

--- a/apps/briefing/models.py
+++ b/apps/briefing/models.py
@@ -1,3 +1,5 @@
+"""Briefing models: user briefings with curated story collections and AI summaries."""
+
 import datetime
 
 import mongoengine as mongo

--- a/apps/briefing/tasks.py
+++ b/apps/briefing/tasks.py
@@ -1,3 +1,5 @@
+"""Briefing tasks: generate and deliver personalized email briefings on schedule."""
+
 import datetime
 
 from django.contrib.auth.models import User

--- a/apps/briefing/views.py
+++ b/apps/briefing/views.py
@@ -1,3 +1,5 @@
+"""Briefing views: manage user briefing feeds with customizable sections and notifications."""
+
 import datetime
 import re
 import zlib

--- a/apps/categories/models.py
+++ b/apps/categories/models.py
@@ -1,3 +1,5 @@
+"""Category models: predefined feed categories for bulk subscription."""
+
 from itertools import groupby
 
 import mongoengine as mongo

--- a/apps/categories/views.py
+++ b/apps/categories/views.py
@@ -1,3 +1,5 @@
+"""Category views: browse and subscribe to feed categories."""
+
 from apps.categories.models import MCategory
 from apps.reader.models import UserSubscriptionFolders
 from utils import json_functions as json

--- a/apps/clustering/models.py
+++ b/apps/clustering/models.py
@@ -1,3 +1,5 @@
+"""Clustering models: detect duplicate and similar stories across feeds."""
+
 import re
 import time
 

--- a/apps/clustering/tasks.py
+++ b/apps/clustering/tasks.py
@@ -1,3 +1,5 @@
+"""Clustering tasks: compute duplicate story clusters using title matching and similarity."""
+
 import datetime
 import time
 

--- a/apps/feed_import/models.py
+++ b/apps/feed_import/models.py
@@ -1,3 +1,5 @@
+"""Feed import models: OPML import/export and OAuth token management."""
+
 import base64
 import datetime
 import pickle

--- a/apps/feed_import/tasks.py
+++ b/apps/feed_import/tasks.py
@@ -1,3 +1,5 @@
+"""Feed import tasks: process OPML imports and exports for bulk subscription management."""
+
 from django.contrib.auth.models import User
 
 from apps.feed_import.models import OPMLImporter, UploadedOPML

--- a/apps/feed_import/views.py
+++ b/apps/feed_import/views.py
@@ -1,3 +1,5 @@
+"""Feed import views: OPML feed import/export and OAuth-based feed synchronization."""
+
 import base64
 import datetime
 import pickle

--- a/apps/mobile/models.py
+++ b/apps/mobile/models.py
@@ -1,3 +1,3 @@
-from django.db import models
+"""Mobile models: placeholder for mobile app data."""
 
-# Create your models here.
+from django.db import models

--- a/apps/mobile/views.py
+++ b/apps/mobile/views.py
@@ -1,3 +1,5 @@
+"""Mobile views: mobile app workspace rendering and asset delivery."""
+
 import base64
 import os
 

--- a/apps/newsletters/models.py
+++ b/apps/newsletters/models.py
@@ -1,3 +1,5 @@
+"""Newsletter models: process incoming email newsletters and manage newsletter feeds."""
+
 import datetime
 import re
 

--- a/apps/newsletters/views.py
+++ b/apps/newsletters/views.py
@@ -1,3 +1,5 @@
+"""Newsletter views: inbound email handling and newsletter encoding repair."""
+
 import json
 from pprint import pprint
 

--- a/apps/notifications/tasks.py
+++ b/apps/notifications/tasks.py
@@ -1,3 +1,5 @@
+"""Notification tasks: queue push notifications for new feed stories."""
+
 from django.contrib.auth.models import User
 
 from apps.notifications.models import MUserFeedNotification

--- a/apps/oauth/models.py
+++ b/apps/oauth/models.py
@@ -1,1 +1,1 @@
-# No models for OAuth. Use MSocialServices model in social.
+"""OAuth models: no models defined; uses MSocialServices from the social app."""

--- a/apps/oauth/views.py
+++ b/apps/oauth/views.py
@@ -1,3 +1,5 @@
+"""OAuth views: authentication flows for connecting to social media platforms."""
+
 import datetime
 import urllib.error
 import urllib.parse

--- a/apps/profile/tasks.py
+++ b/apps/profile/tasks.py
@@ -1,3 +1,5 @@
+"""Profile tasks: user lifecycle management including onboarding, premium tiers, and cleanup."""
+
 import datetime
 
 from django.conf import settings

--- a/apps/push/models.py
+++ b/apps/push/models.py
@@ -1,3 +1,5 @@
+"""PubSubHubbub models: manage push subscriptions for real-time feed updates."""
+
 # Adapted from djpubsubhubbub. See License: http://git.participatoryculture.org/djpubsubhubbub/tree/LICENSE
 
 import hashlib

--- a/apps/push/views.py
+++ b/apps/push/views.py
@@ -1,3 +1,5 @@
+"""PubSubHubbub views: handle push notification callbacks for real-time feed updates."""
+
 # Adapted from djpubsubhubbub. See License: http://git.participatoryculture.org/djpubsubhubbub/tree/LICENSE
 
 import datetime

--- a/apps/reader/tasks.py
+++ b/apps/reader/tasks.py
@@ -1,3 +1,5 @@
+"""Reader tasks: periodic maintenance for homepage freshening and analytics cleanup."""
+
 import datetime
 import time
 

--- a/apps/recommendations/models.py
+++ b/apps/recommendations/models.py
@@ -1,3 +1,5 @@
+"""Recommendation models: feed recommendations with user feedback and approval workflow."""
+
 import datetime
 import os
 import tempfile

--- a/apps/recommendations/views.py
+++ b/apps/recommendations/views.py
@@ -1,3 +1,5 @@
+"""Recommendation views: display and moderate recommended feeds."""
+
 import datetime
 import re
 

--- a/apps/rss_feeds/tasks.py
+++ b/apps/rss_feeds/tasks.py
@@ -1,3 +1,5 @@
+"""RSS feed tasks: orchestrate the feed refresh pipeline including fetch, parse, and push."""
+
 import datetime
 import os
 import shutil

--- a/apps/search/tasks.py
+++ b/apps/search/tasks.py
@@ -1,3 +1,5 @@
+"""Search tasks: index user subscriptions and feeds in Elasticsearch."""
+
 from newsblur_web.celeryapp import app
 from utils import log as logging
 

--- a/apps/social/tasks.py
+++ b/apps/social/tasks.py
@@ -1,3 +1,5 @@
+"""Social tasks: sharing, follower notifications, and third-party integrations."""
+
 from bson.objectid import ObjectId
 from django.contrib.auth.models import User
 

--- a/apps/static/models.py
+++ b/apps/static/models.py
@@ -1,3 +1,3 @@
-from django.db import models
+"""Static models: placeholder for the static pages app."""
 
-# Create your models here.
+from django.db import models

--- a/apps/static/views.py
+++ b/apps/static/views.py
@@ -1,3 +1,5 @@
+"""Static views: render static content pages and application manifests."""
+
 import os
 
 import redis

--- a/apps/statistics/tasks.py
+++ b/apps/statistics/tasks.py
@@ -1,3 +1,5 @@
+"""Statistics tasks: collect system statistics and user feedback."""
+
 from apps.statistics.models import MFeedback, MStatistics
 from newsblur_web.celeryapp import app
 from utils import log as logging

--- a/apps/statistics/views.py
+++ b/apps/statistics/views.py
@@ -1,3 +1,5 @@
+"""Statistics views: dashboard graphs, feedback tables, and revenue reports."""
+
 import base64
 import datetime
 import pickle


### PR DESCRIPTION
## Summary
- Adds one-line module-level docstrings to **35 Python files** that were missing them
- Covers **11 views.py**, **12 models.py**, and **12 tasks.py** files across secondary apps
- Follows up on PR #2069 which documented core apps and Node.js services
- Uses the same `"""Topic: brief description."""` style convention

### views.py (11 files)
ask_ai, briefing, categories, feed_import, mobile, newsletters, oauth, push, recommendations, static, statistics

### models.py (12 files)
api, archive_extension, briefing, categories, clustering, feed_import, mobile, newsletters, oauth, push, recommendations, static

### tasks.py (12 files)
analyzer, ask_ai, briefing, clustering, feed_import, notifications, profile, reader, rss_feeds, search, social, statistics

**Note:** `twitter_fetcher/models.py` was listed in the plan but does not exist in the repository (1 of 14 planned models.py files skipped).

## Test plan
- [x] All 35 modified files pass `py_compile` syntax check
- [x] Docstring-only changes — no behavioral modifications

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
*Automated by [nightshift](https://github.com/marcus/nightshift)*

<!-- nightshift:metadata
task-id: docs-backfill:/Users/sclay/projects/newsblur
task-type: docs-backfill
task-title: Documentation Backfiller
provider: claude
score: 7.8
cost-tier: Low (10-50k)
iterations: 1
duration: 11m12s
run-started: 2026-02-21T02:00:05-08:00
nightshift:metadata -->
