### PR TITLE
Fix black formatting in convert_icons_to_pdf.py

### DIFF
--- a/clients/ios/scripts/convert_icons_to_pdf.py
+++ b/clients/ios/scripts/convert_icons_to_pdf.py
@@ -28,7 +28,7 @@ def convert_svg_to_png(svg_path: Path, png_path: Path, scale: int = 2) -> bool:
     """Convert an SVG file to PNG format at specified scale."""
     try:
         # Read SVG content
-        with open(svg_path, 'r') as f:
+        with open(svg_path, "r") as f:
             svg_content = f.read()
 
         # Replace currentColor with black (will be tinted at runtime)
@@ -38,10 +38,10 @@ def convert_svg_to_png(svg_path: Path, png_path: Path, scale: int = 2) -> bool:
         # Convert to PNG at specified scale (base size is 24x24)
         output_size = 24 * scale
         cairosvg.svg2png(
-            bytestring=svg_content.encode('utf-8'),
+            bytestring=svg_content.encode("utf-8"),
             write_to=str(png_path),
             output_width=output_size,
-            output_height=output_size
+            output_height=output_size,
         )
         return True
     except Exception as e:


### PR DESCRIPTION
## Summary
- Apply black formatting to `clients/ios/scripts/convert_icons_to_pdf.py` — the only file in the codebase that was not conformant
- Normalizes single quotes to double quotes and adds a trailing comma in a multi-line function call

## Test plan
- [x] Verified `black --line-length 110` reports no further changes needed
- [x] Verified `isort --profile black` reports no changes needed
- [ ] `make lint` passes in Docker

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
*Automated by [nightshift](https://github.com/marcus/nightshift)*

<!-- nightshift:metadata
task-id: lint-fix:/Users/sclay/projects/newsblur
task-type: lint-fix
task-title: Linter Fixes
provider: claude
score: 4.3
cost-tier: Low (10-50k)
iterations: 1
duration: 4m7s
run-started: 2026-02-22T02:00:06-08:00
nightshift:metadata -->
