### PR TITLE
Fix black formatting in 5 files

### DIFF
--- a/apps/analyzer/models.py
+++ b/apps/analyzer/models.py
@@ -929,11 +929,21 @@ def get_classifiers_for_user(
     # it does its own scope check via classifier_matches_story_feed).
     if folder_feed_ids is not None and feed_id and not isinstance(feed_id, list):
         active_feed_id = int(feed_id)
-        classifier_authors = [c for c in classifier_authors if classifier_matches_story_feed(c, active_feed_id, folder_feed_ids)]
-        classifier_titles = [c for c in classifier_titles if classifier_matches_story_feed(c, active_feed_id, folder_feed_ids)]
-        classifier_tags = [c for c in classifier_tags if classifier_matches_story_feed(c, active_feed_id, folder_feed_ids)]
-        classifier_texts = [c for c in classifier_texts if classifier_matches_story_feed(c, active_feed_id, folder_feed_ids)]
-        classifier_urls = [c for c in classifier_urls if classifier_matches_story_feed(c, active_feed_id, folder_feed_ids)]
+        classifier_authors = [
+            c for c in classifier_authors if classifier_matches_story_feed(c, active_feed_id, folder_feed_ids)
+        ]
+        classifier_titles = [
+            c for c in classifier_titles if classifier_matches_story_feed(c, active_feed_id, folder_feed_ids)
+        ]
+        classifier_tags = [
+            c for c in classifier_tags if classifier_matches_story_feed(c, active_feed_id, folder_feed_ids)
+        ]
+        classifier_texts = [
+            c for c in classifier_texts if classifier_matches_story_feed(c, active_feed_id, folder_feed_ids)
+        ]
+        classifier_urls = [
+            c for c in classifier_urls if classifier_matches_story_feed(c, active_feed_id, folder_feed_ids)
+        ]
 
     feeds = []
     for f in classifier_feeds:

--- a/apps/clustering/models.py
+++ b/apps/clustering/models.py
@@ -239,7 +239,9 @@ def find_title_clusters(stories, original_feed_map=None):
     return clusters
 
 
-def find_semantic_clusters(stories, feed_ids, lookback_date=None, min_score=30, original_feed_map=None, story_title_map=None):
+def find_semantic_clusters(
+    stories, feed_ids, lookback_date=None, min_score=30, original_feed_map=None, story_title_map=None
+):
     """Find semantically similar stories using Elasticsearch more_like_this.
 
     For each story, sends its title + content as text to ES MLT to find
@@ -399,7 +401,9 @@ def find_semantic_clusters(stories, feed_ids, lookback_date=None, min_score=30, 
     return clusters
 
 
-def merge_clusters(title_clusters, semantic_clusters, story_feed_map=None, original_feed_map=None, story_title_map=None):
+def merge_clusters(
+    title_clusters, semantic_clusters, story_feed_map=None, original_feed_map=None, story_title_map=None
+):
     """Merge title-based and semantic clusters using union-find.
 
     If any story appears in both a title cluster and a semantic cluster,

--- a/apps/clustering/tasks.py
+++ b/apps/clustering/tasks.py
@@ -155,8 +155,11 @@ def ComputeStoryClusters(feed_id):
     semantic_clusters = {}
     if unclustered_stories:
         semantic_clusters = find_semantic_clusters(
-            unclustered_stories, all_feed_ids, lookback_date=lookback,
-            original_feed_map=original_feed_map, story_title_map=story_title_map,
+            unclustered_stories,
+            all_feed_ids,
+            lookback_date=lookback,
+            original_feed_map=original_feed_map,
+            story_title_map=story_title_map,
         )
 
     # Merge title and semantic clusters

--- a/apps/clustering/tests.py
+++ b/apps/clustering/tests.py
@@ -245,9 +245,7 @@ class Test_SemanticClusterFalsePositive(TestCase):
         )
 
         # Rivian stories should still be clustered together
-        rivian_clustered = any(
-            "200:bbb" in members and "300:ccc" in members for members in merged.values()
-        )
+        rivian_clustered = any("200:bbb" in members and "300:ccc" in members for members in merged.values())
         self.assertTrue(rivian_clustered, "Rivian Apple Watch stories should remain clustered")
 
     def test_merge_without_title_map_unions_everything(self):

--- a/clients/ios/scripts/convert_icons_to_pdf.py
+++ b/clients/ios/scripts/convert_icons_to_pdf.py
@@ -28,7 +28,7 @@ def convert_svg_to_png(svg_path: Path, png_path: Path, scale: int = 2) -> bool:
     """Convert an SVG file to PNG format at specified scale."""
     try:
         # Read SVG content
-        with open(svg_path, 'r') as f:
+        with open(svg_path, "r") as f:
             svg_content = f.read()
 
         # Replace currentColor with black (will be tinted at runtime)
@@ -38,10 +38,10 @@ def convert_svg_to_png(svg_path: Path, png_path: Path, scale: int = 2) -> bool:
         # Convert to PNG at specified scale (base size is 24x24)
         output_size = 24 * scale
         cairosvg.svg2png(
-            bytestring=svg_content.encode('utf-8'),
+            bytestring=svg_content.encode("utf-8"),
             write_to=str(png_path),
             output_width=output_size,
-            output_height=output_size
+            output_height=output_size,
         )
         return True
     except Exception as e:


### PR DESCRIPTION
## Summary
- Auto-fixed black formatting violations in 5 Python files: `apps/analyzer/models.py`, `apps/clustering/models.py`, `apps/clustering/tasks.py`, `apps/clustering/tests.py`, `clients/ios/scripts/convert_icons_to_pdf.py`
- Changes are purely mechanical: line-length wrapping for long function signatures and list comprehensions, trailing comma formatting, and quote normalization
- `make lint` passes cleanly (isort, black, flake8)

Nightshift-Task: lint-fix
Nightshift-Ref: https://github.com/marcus/nightshift

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
*Automated by [nightshift](https://github.com/marcus/nightshift)*

<!-- nightshift:metadata
task-id: lint-fix:/Users/sclay/projects/newsblur
task-type: lint-fix
task-title: Linter Fixes
provider: claude
score: 4.1
cost-tier: Low (10-50k)
iterations: 1
duration: 3m26s
run-started: 2026-02-24T02:00:05-08:00
nightshift:metadata -->
