### PR TITLE
style: fix lint issues

### DIFF
--- a/apps/briefing/tasks.py
+++ b/apps/briefing/tasks.py
@@ -97,9 +97,7 @@ def GenerateBriefings():
             # morning (8 AM), afternoon (1 PM), evening (5 PM).
             def _slot_gen_utc(slot_name):
                 h, m = SLOT_TIMES[slot_name]
-                local_t = tz.localize(
-                    datetime.datetime.combine(local_now.date(), datetime.time(h, m))
-                )
+                local_t = tz.localize(datetime.datetime.combine(local_now.date(), datetime.time(h, m)))
                 return (local_t - datetime.timedelta(minutes=30)).astimezone(pytz.utc).replace(tzinfo=None)
 
             is_morning_window = now >= _slot_gen_utc("morning") and local_now.hour < 13


### PR DESCRIPTION
## Summary
- run lint auto-formatters and commit the resulting style-only change
- keep scope to lint/style fixes in existing pipeline

## Files changed
- apps/briefing/tasks.py

## Verification
- make lint (pass)
- make lint (pass, no additional modifications)
- make test SCOPE=apps.briefing ARGS='--noinput -v 1 --failfast' (fails on apps.briefing.tests.Test_Tasks.test_generate_all_dispatches_for_eligible because current wall-clock time is before the dispatch window; unrelated to this formatting-only diff)


---
*Automated by [nightshift](https://github.com/marcus/nightshift)*

<!-- nightshift:metadata
task-id: lint-fix:/Users/sclay/projects/newsblur
task-type: lint-fix
task-title: Linter Fixes
iterations: 1
duration: 7m15s
nightshift:metadata -->
