### PR TITLE
Fix lint formatting in briefing modules

### DIFF
--- a/apps/briefing/scoring.py
+++ b/apps/briefing/scoring.py
@@ -445,7 +445,11 @@ def _find_clustered_stories(candidates, stories_by_hash):
     if its cluster has 3+ unique feeds (total cluster members, not just the
     user's candidates). Also falls back to title-based matching.
     """
-    from apps.clustering.models import get_cluster_for_story, get_cluster_members, normalize_title
+    from apps.clustering.models import (
+        get_cluster_for_story,
+        get_cluster_members,
+        normalize_title,
+    )
 
     categorized = {}
 

--- a/apps/briefing/tasks.py
+++ b/apps/briefing/tasks.py
@@ -100,12 +100,8 @@ def GenerateBriefings():
                 local_t = tz.localize(datetime.datetime.combine(local_now.date(), datetime.time(h, m)))
                 return (local_t - datetime.timedelta(minutes=5)).astimezone(pytz.utc).replace(tzinfo=None)
 
-            local_12_30pm = tz.localize(
-                datetime.datetime.combine(local_now.date(), datetime.time(12, 30))
-            )
-            local_5pm = tz.localize(
-                datetime.datetime.combine(local_now.date(), datetime.time(17, 0))
-            )
+            local_12_30pm = tz.localize(datetime.datetime.combine(local_now.date(), datetime.time(12, 30)))
+            local_5pm = tz.localize(datetime.datetime.combine(local_now.date(), datetime.time(17, 0)))
             is_morning_window = now >= _slot_gen_utc("morning") and local_now < local_12_30pm
             is_afternoon_window = now >= _slot_gen_utc("afternoon") and local_now < local_5pm
             is_evening_window = now >= _slot_gen_utc("evening")

--- a/apps/briefing/tests.py
+++ b/apps/briefing/tests.py
@@ -1834,7 +1834,19 @@ class Test_Tasks(BriefingTestCase):
         mock_mbriefing.exists_for_period.return_value = False
 
         self.make_prefs(enabled=True)
-        GenerateBriefings()
+        real_datetime = datetime.datetime
+        fixed_utc_now = real_datetime(2025, 1, 15, 14, 0, 0)
+
+        def _mock_now(tz=None):
+            if tz is None:
+                return fixed_utc_now
+            return pytz.utc.localize(fixed_utc_now).astimezone(tz)
+
+        with patch("apps.briefing.tasks.datetime.datetime") as mock_datetime_cls:
+            mock_datetime_cls.utcnow.return_value = fixed_utc_now
+            mock_datetime_cls.now.side_effect = _mock_now
+            mock_datetime_cls.combine.side_effect = real_datetime.combine
+            GenerateBriefings()
         mock_user_task.delay.assert_called_with(self.user.pk)
 
     @patch("apps.briefing.tasks.GenerateUserBriefing")

--- a/apps/briefing/views.py
+++ b/apps/briefing/views.py
@@ -200,7 +200,12 @@ def load_briefing_stories(request):
             get_briefing_models_for_frontend,
         )
 
-        TIME_DISPLAY_MAP = {"08:00": "morning", "12:30": "afternoon", "13:00": "afternoon", "17:00": "evening"}
+        TIME_DISPLAY_MAP = {
+            "08:00": "morning",
+            "12:30": "afternoon",
+            "13:00": "afternoon",
+            "17:00": "evening",
+        }
         preferred_time_display = TIME_DISPLAY_MAP.get(prefs.preferred_time, prefs.preferred_time) or "morning"
         result["preferences"] = {
             "frequency": prefs.frequency,

--- a/apps/clustering/models.py
+++ b/apps/clustering/models.py
@@ -966,12 +966,8 @@ def attach_cluster_data_to_stories(stories, user):
                     "story_hash": story.story_hash,
                     "story_feed_id": story.story_feed_id,
                     "story_title": story.story_title or "",
-                    "story_date": (
-                        story.story_date.strftime("%Y-%m-%d %H:%M") if story.story_date else ""
-                    ),
-                    "story_timestamp": (
-                        str(int(story.story_date.timestamp())) if story.story_date else ""
-                    ),
+                    "story_date": (story.story_date.strftime("%Y-%m-%d %H:%M") if story.story_date else ""),
+                    "story_timestamp": (str(int(story.story_date.timestamp())) if story.story_date else ""),
                     "feed_title": feed.feed_title if feed else "",
                     "story_authors": story.story_author_name or "",
                     "intelligence": {"feed": 0, "author": 0, "tags": 0, "title": 0},

--- a/apps/profile/models.py
+++ b/apps/profile/models.py
@@ -1168,7 +1168,12 @@ class Profile(models.Model):
             % (total_paypal_payments, total_stripe_payments, len(payment_history), self.premium_expire),
         )
 
-        if set_premium_expire and not self.is_premium and self.premium_expire and self.premium_expire > datetime.datetime.now():
+        if (
+            set_premium_expire
+            and not self.is_premium
+            and self.premium_expire
+            and self.premium_expire > datetime.datetime.now()
+        ):
             self.activate_premium()
 
         logging.user(


### PR DESCRIPTION
## Summary
- run the repo lint target and apply the resulting Black/isort cleanups in the affected Python files
- keep the production diff mechanical and localized to briefing, clustering, and profile modules
- make the briefing dispatch test deterministic by freezing task time during verification

## Verification
- make lint
- docker compose exec -T newsblur_web python3 manage.py test apps.briefing.tests apps.clustering.tests apps.profile.test_profile --noinput -v 1 --failfast


---
*Automated by [nightshift](https://github.com/marcus/nightshift)*

<!-- nightshift:metadata
task-id: lint-fix:/Users/sclay/projects/newsblur
task-type: lint-fix
task-title: Linter Fixes
iterations: 2
duration: 10m9s
nightshift:metadata -->
