### PR TITLE
Android: Disable setAllowFileAccess in NewsblurWebview

### DIFF
--- a/clients/android/NewsBlur/app/src/main/java/com/newsblur/web/NewsblurWebview.java
+++ b/clients/android/NewsBlur/app/src/main/java/com/newsblur/web/NewsblurWebview.java
@@ -56,7 +56,12 @@ public class NewsblurWebview extends WebView {
         getSettings().setCacheMode(WebSettings.LOAD_CACHE_ELSE_NETWORK);
         getSettings().setDomStorageEnabled(true);
         getSettings().setSupportZoom(true);
-        getSettings().setAllowFileAccess(true);
+        // Reading WebView is loaded with the https appassets virtual host
+        // (READING_BASE_URL = https://appassets.androidplatform.net/assets/)
+        // and serves all bundled resources through
+        // WebViewAssetLoader.shouldInterceptRequest. It never loads a file://
+        // URL, so setAllowFileAccess(true) is not load-bearing here.
+        getSettings().setAllowFileAccess(false);
 
         // Remove default web search and share to accommodate the custom contextual menu
         getSettings().setDisabledActionModeMenuItems(WebSettings.MENU_ITEM_WEB_SEARCH);


### PR DESCRIPTION
Closes #2109.

`NewsblurWebview` already integrates `WebViewAssetLoader` for bundled resources, and `ReadingItemFragment` loads articles with the https `appassets` virtual host:

```java
// AppConstants.java
public final static String READING_BASE_URL = "https://appassets.androidplatform.net/assets/";

// NewsblurWebview.java
class NewsblurWebViewClient extends WebViewClient {
    @Override
    public WebResourceResponse shouldInterceptRequest(WebView view, WebResourceRequest request) {
        return assetLoader.shouldInterceptRequest(request.getUrl());
    }
    ...
}
```

The reading WebView never loads a `file://` URL as the main frame, and asset requests are served by `assetLoader.shouldInterceptRequest`, which reads from the `AssetManager` regardless of `setAllowFileAccess`.

### Change

In `NewsblurWebview` constructor, flip `setAllowFileAccess(true)` to `setAllowFileAccess(false)`. Short inline comment recording the asset-loader rationale.

The asset-loader pathway is unaffected. The change is contained to the Android client.

Assisted-by: Claude (Anthropic)