### PR TITLE
add support for OpenAI-compatible LLM providers

### DIFF
--- a/apps/ask_ai/providers.py
+++ b/apps/ask_ai/providers.py
@@ -20,7 +20,8 @@ def _is_placeholder(key):
 class LLMProvider(ABC):
     """Abstract base class for LLM providers."""
 
-    def __init__(self):
+    def __init__(self, model_config: Optional[dict] = None):
+        self.model_config = model_config or {}
         # Track usage from the last API call
         self._last_input_tokens = 0
         self._last_output_tokens = 0
@@ -203,6 +204,124 @@ class OpenAIProvider(LLMProvider):
         return f"OpenAI API error: {str(error)}"
 
 
+class OpenAICompatibleProvider(LLMProvider):
+    """Generic OpenAI-compatible chat completions provider."""
+
+    DEFAULT_API_KEY_SETTING = "OPENAI_COMPATIBLE_API_KEY"
+
+    def _api_key_setting(self) -> str:
+        return self.model_config.get("api_key_setting", self.DEFAULT_API_KEY_SETTING)
+
+    def _api_key(self) -> Optional[str]:
+        if self.model_config.get("api_key"):
+            return self.model_config["api_key"]
+        return getattr(settings, self._api_key_setting(), None)
+
+    def is_configured(self) -> bool:
+        key = self._api_key()
+        return bool(key) and not _is_placeholder(key)
+
+    def _client(self):
+        kwargs = {"api_key": self._api_key()}
+        if self.model_config.get("base_url"):
+            kwargs["base_url"] = self.model_config["base_url"]
+        if self.model_config.get("default_headers"):
+            kwargs["default_headers"] = self.model_config["default_headers"]
+        return openai.OpenAI(**kwargs)
+
+    def _merged_extra_body(self, thinking_config: Optional[dict] = None) -> Optional[dict]:
+        extra_body = dict(self.model_config.get("extra_body") or {})
+        if thinking_config and "reasoning_effort" in thinking_config:
+            extra_body["reasoning_effort"] = thinking_config["reasoning_effort"]
+        return extra_body or None
+
+    def _max_tokens_kwargs(self, max_tokens: int) -> dict:
+        parameter = self.model_config.get("max_tokens_parameter", "max_tokens")
+        multiplier = self.model_config.get("max_tokens_multiplier", 1)
+        effective_max = max_tokens * multiplier
+        minimum = self.model_config.get("max_tokens_minimum")
+        if minimum:
+            effective_max = max(effective_max, minimum)
+        return {parameter: effective_max}
+
+    def _chat_completion_kwargs(
+        self,
+        messages: list,
+        model_id: str,
+        *,
+        stream: bool = False,
+        max_tokens: Optional[int] = None,
+        thinking_config: Optional[dict] = None,
+    ) -> dict:
+        kwargs = {
+            "model": model_id,
+            "messages": messages,
+        }
+        if stream:
+            kwargs["stream"] = True
+            stream_options = self.model_config.get(
+                "stream_options",
+                {"include_usage": True},
+            )
+            if stream_options:
+                kwargs["stream_options"] = stream_options
+        if max_tokens is not None:
+            kwargs.update(self._max_tokens_kwargs(max_tokens))
+        extra_body = self._merged_extra_body(thinking_config)
+        if extra_body:
+            kwargs["extra_body"] = extra_body
+        return kwargs
+
+    def stream_response(
+        self, messages: list, model_id: str, thinking_config: Optional[dict] = None
+    ) -> Generator[str, None, None]:
+        client = self._client()
+        kwargs = self._chat_completion_kwargs(
+            messages,
+            model_id,
+            stream=True,
+            thinking_config=thinking_config,
+        )
+        response = client.chat.completions.create(**kwargs)
+
+        for chunk in response:
+            # The final chunk contains usage info
+            if chunk.usage:
+                self._last_input_tokens = chunk.usage.prompt_tokens
+                self._last_output_tokens = chunk.usage.completion_tokens
+            if chunk.choices and chunk.choices[0].delta.content:
+                yield chunk.choices[0].delta.content
+
+    def generate(self, messages: list, model_id: str, max_tokens: int = 4096) -> str:
+        client = self._client()
+        kwargs = self._chat_completion_kwargs(messages, model_id, max_tokens=max_tokens)
+        response = client.chat.completions.create(**kwargs)
+
+        if response.usage:
+            self._last_input_tokens = response.usage.prompt_tokens
+            self._last_output_tokens = response.usage.completion_tokens
+
+        return response.choices[0].message.content or ""
+
+    @property
+    def error_types(self) -> tuple:
+        return (openai.APITimeoutError, openai.APIError)
+
+    def format_error(self, error: Exception) -> str:
+        provider_name = self.model_config.get("vendor_display", "OpenAI-compatible")
+        api_key_setting = self._api_key_setting()
+        if isinstance(error, openai.APITimeoutError):
+            return f"{provider_name} API timeout"
+        if isinstance(error, openai.APIStatusError):
+            if error.status_code == 401:
+                return f"{provider_name} API key is invalid. Please check your {api_key_setting} setting."
+            if error.status_code == 403:
+                return f"{provider_name} API access denied. Your API key may be invalid or lack permissions. Please check your {api_key_setting} setting."
+            if error.status_code == 429:
+                return f"{provider_name} API rate limit exceeded. Please try again later."
+        return f"{provider_name} API error: {str(error)}"
+
+
 class XAIProvider(LLMProvider):
     """xAI/Grok provider implementation (OpenAI-compatible API)."""
 
@@ -367,9 +486,30 @@ LLM_EXCEPTIONS = (
 PROVIDER_CLASSES = {
     "anthropic": AnthropicProvider,
     "openai": OpenAIProvider,
+    "openai_compatible": OpenAICompatibleProvider,
     "google": GeminiProvider,
     "xai": XAIProvider,
 }
+
+OPENAI_COMPAT_CONFIG_KEYS = (
+    "api_key",
+    "api_key_setting",
+    "base_url",
+    "default_headers",
+    "stream_options",
+    "max_tokens_parameter",
+    "max_tokens_multiplier",
+    "max_tokens_minimum",
+    "extra_body",
+)
+
+
+def _copy_openai_compat_config(entry: dict, cfg: dict):
+    if entry.get("provider_class") != OpenAICompatibleProvider:
+        return
+    for config_key in OPENAI_COMPAT_CONFIG_KEYS:
+        if config_key in cfg:
+            entry[config_key] = cfg[config_key]
 
 # Model registry: single source of truth for all model configuration.
 # Each entry contains everything needed by both backend and frontend.
@@ -427,7 +567,7 @@ def _load_models():
     Self-hosters can define ASK_AI_MODELS in settings as a dict of model configs:
         ASK_AI_MODELS = {
             "my-model": {
-                "provider": "openai",  # one of: anthropic, openai, google, xai
+                "provider": "openai",  # one of: anthropic, openai, openai_compatible, google, xai
                 "model_id": "gpt-4o-mini",
                 "display_name": "GPT-4o Mini",
                 "order": 1,
@@ -448,14 +588,15 @@ def _load_models():
             "provider_class": provider_class,
             "model_id": cfg["model_id"],
             "display_name": cfg.get("display_name", key),
-            "vendor": provider_slug,
-            "vendor_display": cfg.get("vendor_display", provider_slug.title()),
+            "vendor": cfg.get("vendor", provider_slug),
+            "vendor_display": cfg.get("vendor_display", cfg.get("vendor", provider_slug).title()),
             "order": cfg.get("order", 99),
         }
         if "thinking_config" in cfg:
             entry["thinking_config"] = cfg["thinking_config"]
         if "thinking_model_id" in cfg:
             entry["thinking_model_id"] = cfg["thinking_model_id"]
+        _copy_openai_compat_config(entry, cfg)
         models[key] = entry
     return models if models else _DEFAULT_MODELS
 
@@ -512,7 +653,7 @@ def get_provider(model_name: str, thinking: bool = False) -> tuple[LLMProvider, 
     else:
         model_id = model["model_id"]
         thinking_config = None
-    return model["provider_class"](), model_id, thinking_config
+    return model["provider_class"](model), model_id, thinking_config
 
 
 # Briefing model registry: cheap models optimized for daily briefing generation.
@@ -576,14 +717,16 @@ def _load_briefing_models():
         provider_class = PROVIDER_CLASSES.get(provider_slug)
         if not provider_class:
             continue
-        models[key] = {
+        entry = {
             "provider_class": provider_class,
             "model_id": cfg["model_id"],
             "display_name": cfg.get("display_name", key),
-            "vendor": provider_slug,
-            "vendor_display": cfg.get("vendor_display", provider_slug.title()),
+            "vendor": cfg.get("vendor", provider_slug),
+            "vendor_display": cfg.get("vendor_display", cfg.get("vendor", provider_slug).title()),
             "order": cfg.get("order", 99),
         }
+        _copy_openai_compat_config(entry, cfg)
+        models[key] = entry
     return models if models else _DEFAULT_BRIEFING_MODELS
 
 
@@ -616,4 +759,4 @@ def get_briefing_provider(model_name: str) -> tuple[LLMProvider, str]:
     if not model_name or model_name not in BRIEFING_MODELS:
         model_name = DEFAULT_BRIEFING_MODEL
     model = BRIEFING_MODELS[model_name]
-    return model["provider_class"](), model["model_id"]
+    return model["provider_class"](model), model["model_id"]

--- a/apps/ask_ai/tests.py
+++ b/apps/ask_ai/tests.py
@@ -1,0 +1,167 @@
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from django.test import SimpleTestCase, override_settings
+
+from apps.ask_ai import providers
+
+
+class OpenAICompatibleProviderTest(SimpleTestCase):
+    @override_settings(
+        OPENROUTER_API_KEY="openrouter-key",
+        ASK_AI_MODELS={
+            "openrouter-auto": {
+                "provider": "openai_compatible",
+                "model_id": "openrouter/auto",
+                "display_name": "OpenRouter Auto",
+                "vendor": "openrouter",
+                "vendor_display": "OpenRouter",
+                "api_key_setting": "OPENROUTER_API_KEY",
+                "base_url": "https://openrouter.ai/api/v1",
+                "default_headers": {
+                    "HTTP-Referer": "https://newsblur.example",
+                    "X-Title": "NewsBlur Self Hosted",
+                },
+                "stream_options": {"include_usage": True},
+                "max_tokens_parameter": "max_tokens",
+                "max_tokens_multiplier": 1,
+                "extra_body": {"provider": {"order": ["openai"]}},
+            },
+        },
+    )
+    def test_custom_openrouter_model_uses_openai_compatible_client_config(self):
+        models = providers._load_models()
+        with patch.object(providers, "MODELS", models), patch.object(
+            providers, "VALID_MODELS", list(models.keys())
+        ), patch.object(providers, "MODEL_VENDORS", {key: m["vendor"] for key, m in models.items()}):
+            provider, model_id, _thinking_config = providers.get_provider("openrouter-auto")
+
+            self.assertIsInstance(provider, providers.OpenAICompatibleProvider)
+            self.assertEqual(model_id, "openrouter/auto")
+            self.assertTrue(provider.is_configured())
+            self.assertEqual(providers.MODEL_VENDORS["openrouter-auto"], "openrouter")
+
+            client = MagicMock()
+            response = MagicMock()
+            response.usage = SimpleNamespace(prompt_tokens=3, completion_tokens=5)
+            response.choices = [SimpleNamespace(message=SimpleNamespace(content="ok"))]
+            client.chat.completions.create.return_value = response
+
+            with patch("apps.ask_ai.providers.openai.OpenAI", return_value=client) as openai_client:
+                result = provider.generate([{"role": "user", "content": "hello"}], model_id, max_tokens=100)
+
+            self.assertEqual(result, "ok")
+            openai_client.assert_called_once_with(
+                api_key="openrouter-key",
+                base_url="https://openrouter.ai/api/v1",
+                default_headers={
+                    "HTTP-Referer": "https://newsblur.example",
+                    "X-Title": "NewsBlur Self Hosted",
+                },
+            )
+            client.chat.completions.create.assert_called_once_with(
+                model="openrouter/auto",
+                messages=[{"role": "user", "content": "hello"}],
+                max_tokens=100,
+                extra_body={"provider": {"order": ["openai"]}},
+            )
+
+    @override_settings(
+        BRIEFING_MODELS={
+            "local": {
+                "provider": "openai_compatible",
+                "model_id": "local-model",
+                "display_name": "Local Model",
+                "api_key": "local-key",
+                "base_url": "http://localhost:8080/v1",
+                "stream_options": False,
+                "max_tokens_parameter": "max_tokens",
+                "max_tokens_multiplier": 1,
+            },
+        },
+    )
+    def test_custom_briefing_local_model_omits_stream_options_and_uses_max_tokens(self):
+        briefing_models = providers._load_briefing_models()
+        with patch.object(providers, "BRIEFING_MODELS", briefing_models):
+            provider, model_id = providers.get_briefing_provider("local")
+
+            self.assertIsInstance(provider, providers.OpenAICompatibleProvider)
+            self.assertEqual(model_id, "local-model")
+            self.assertTrue(provider.is_configured())
+
+            client = MagicMock()
+            chunk = SimpleNamespace(
+                usage=SimpleNamespace(prompt_tokens=7, completion_tokens=11),
+                choices=[SimpleNamespace(delta=SimpleNamespace(content="chunk"))],
+            )
+            client.chat.completions.create.return_value = iter([chunk])
+
+            with patch("apps.ask_ai.providers.openai.OpenAI", return_value=client) as openai_client:
+                chunks = list(provider.stream_response([{"role": "user", "content": "hello"}], model_id))
+
+                self.assertEqual(chunks, ["chunk"])
+                openai_client.assert_called_once_with(api_key="local-key", base_url="http://localhost:8080/v1")
+                client.chat.completions.create.assert_called_once_with(
+                    model="local-model",
+                    messages=[{"role": "user", "content": "hello"}],
+                    stream=True,
+                )
+
+                client.chat.completions.create.reset_mock()
+                response = MagicMock()
+                response.usage = None
+                response.choices = [SimpleNamespace(message=SimpleNamespace(content="done"))]
+                client.chat.completions.create.return_value = response
+
+                result = provider.generate([{"role": "user", "content": "hello"}], model_id, max_tokens=123)
+
+                self.assertEqual(result, "done")
+                client.chat.completions.create.assert_called_once_with(
+                    model="local-model",
+                    messages=[{"role": "user", "content": "hello"}],
+                    max_tokens=123,
+                )
+
+    @override_settings(
+        ASK_AI_MODELS={
+            "openrouter-auto": {
+                "provider": "openai_compatible",
+                "model_id": "openrouter/auto",
+                "display_name": "OpenRouter Auto",
+                "vendor": "openrouter",
+                "vendor_display": "OpenRouter",
+                "api_key": "secret",
+                "api_key_setting": "OPENROUTER_API_KEY",
+                "base_url": "https://openrouter.ai/api/v1",
+                "default_headers": {"X-Title": "NewsBlur"},
+            },
+        },
+    )
+    def test_frontend_model_serialization_does_not_expose_transport_config(self):
+        models = providers._load_models()
+        with patch.object(providers, "MODELS", models):
+            serialized = providers.get_models_for_frontend()
+
+        self.assertEqual(
+            serialized,
+            [
+                {
+                    "key": "openrouter-auto",
+                    "display_name": "OpenRouter Auto",
+                    "vendor": "openrouter",
+                    "vendor_display": "OpenRouter",
+                }
+            ],
+        )
+
+    @override_settings(
+        ASK_AI_MODELS={
+            "unknown": {
+                "provider": "unknown",
+                "model_id": "unknown-model",
+                "display_name": "Unknown",
+            },
+        },
+    )
+    def test_unknown_provider_slugs_fall_back_to_defaults(self):
+        self.assertIs(providers._load_models(), providers._DEFAULT_MODELS)

--- a/apps/webfeed/tasks.py
+++ b/apps/webfeed/tasks.py
@@ -78,6 +78,14 @@ NAV_INDICATORS = [
 ]
 
 
+def get_webfeed_briefing_model():
+    """Resolve the configured briefing model key and metadata for webfeed analysis."""
+    from apps.ask_ai.providers import BRIEFING_MODELS
+
+    model_name = getattr(settings, "WEBFEED_MODEL", "haiku")
+    return model_name, BRIEFING_MODELS[model_name]
+
+
 def strip_navigation_elements(html_text, gentle=False):
     """Remove navigation, header, footer, and other non-content elements
     to help the LLM focus on main content patterns.
@@ -342,9 +350,17 @@ def AnalyzeWebFeedPage(user_id, url, request_id=None, story_hint=None):
 
         html_hash = hashlib.sha256(page_html[:10000].encode("utf-8", errors="replace")).hexdigest()[:16]
 
+        # Step 2: Call configured briefing model for XPath analysis
+        from apps.ask_ai.providers import LLM_EXCEPTIONS, get_briefing_provider
+
+        model_name, model_config = get_webfeed_briefing_model()
+        model_display = model_config.get("display_name", model_name)
+        vendor = model_config.get("vendor", "unknown")
+        vendor_display = model_config.get("vendor_display", vendor.title())
+
         logging.user(
             user,
-            f"~BB~FWWeb Feed: Fetched ~SB{len(page_html)}~SN bytes, analyzing with Claude",
+            f"~BB~FWWeb Feed: Fetched ~SB{len(page_html)}~SN bytes, analyzing with ~SB{model_display}~SN",
         )
 
         publish_event("progress", {"message": "Preparing page..."})
@@ -360,14 +376,11 @@ def AnalyzeWebFeedPage(user_id, url, request_id=None, story_hint=None):
 
         publish_event("progress", {"message": "Finding story patterns..."})
 
-        # Step 2: Call Claude for XPath analysis
-        from apps.ask_ai.providers import LLM_EXCEPTIONS, get_briefing_provider
-
         messages = get_analysis_messages(url, cleaned_html, story_hint=story_hint)
-        provider, model_id = get_briefing_provider("haiku")
+        provider, model_id = get_briefing_provider(model_name)
 
         if not provider.is_configured():
-            error_msg = "Anthropic API key not configured"
+            error_msg = f"{vendor_display} API key not configured"
             publish_event("error", {"error": error_msg})
             return {"code": -1, "message": error_msg}
 
@@ -380,7 +393,7 @@ def AnalyzeWebFeedPage(user_id, url, request_id=None, story_hint=None):
         # Record LLM cost
         input_tokens, output_tokens = provider.get_last_usage()
         LLMCostTracker.record_usage(
-            provider="anthropic",
+            provider=vendor,
             model=model_id,
             feature="webfeed",
             input_tokens=input_tokens,

--- a/apps/webfeed/tests.py
+++ b/apps/webfeed/tests.py
@@ -1,10 +1,15 @@
 import hashlib
 from unittest.mock import MagicMock, patch
 
-from django.test import TestCase
+from django.test import TestCase, override_settings
 
+from apps.ask_ai import providers
 from apps.webfeed.models import MWebFeedConfig
-from apps.webfeed.tasks import extract_image_url, extract_preview_stories
+from apps.webfeed.tasks import (
+    AnalyzeWebFeedPage,
+    extract_image_url,
+    extract_preview_stories,
+)
 from utils.webfeed_fetcher import WebFeedFetcher
 
 
@@ -161,6 +166,67 @@ class Test_GuidGeneration(TestCase):
 
         guid = fetcher._generate_guid("https://example.com/test", "Test")
         self.assertEqual(len(guid), 32)
+
+
+class Test_AnalyzeWebFeedPageModelSelection(TestCase):
+    html = "<html><body></body></html>"
+
+    variants_json = """
+    [{
+        "story_container": "//article",
+        "title": ".//h2/text()",
+        "link": ".//a/@href"
+    }]
+    """
+
+    def _model_config(self, vendor="local", vendor_display="Local"):
+        return {
+            "display_name": "Local Model",
+            "vendor": vendor,
+            "vendor_display": vendor_display,
+            "model_id": "local-model",
+        }
+
+    def _run_analysis(self):
+        user = MagicMock()
+        user.username = "webfeed-test"
+
+        with patch("apps.webfeed.tasks.redis.Redis") as redis_mock, patch(
+            "apps.webfeed.tasks.User.objects.get",
+            return_value=user,
+        ), patch(
+            "apps.webfeed.tasks.fetch_page_html",
+            return_value=self.html,
+        ), patch(
+            "apps.webfeed.tasks.get_analysis_messages",
+            return_value=[{"role": "user", "content": "analyze"}],
+        ), patch("apps.statistics.rtrending_webfeeds.RTrendingWebFeed.record_analysis_result"):
+            redis_mock.return_value.publish = MagicMock()
+            return AnalyzeWebFeedPage.run(1, "https://example.com", request_id="request-token")
+
+    @override_settings(WEBFEED_MODEL="openrouter")
+    def test_webfeed_uses_configured_model_for_provider_and_cost_tracking(self):
+        provider = MagicMock()
+        provider.is_configured.return_value = True
+        provider.stream_response.return_value = [self.variants_json]
+        provider.get_last_usage.return_value = (31, 11)
+        briefing_models = {"openrouter": self._model_config(vendor="openrouter", vendor_display="OpenRouter")}
+
+        with patch.object(providers, "BRIEFING_MODELS", briefing_models), patch.object(
+            providers,
+            "DEFAULT_BRIEFING_MODEL",
+            "openrouter",
+        ), patch(
+            "apps.ask_ai.providers.get_briefing_provider",
+            return_value=(provider, "openrouter-model"),
+        ) as get_provider, patch("apps.webfeed.tasks.LLMCostTracker.record_usage") as record_usage:
+            result = self._run_analysis()
+
+        self.assertEqual(result["code"], 1)
+        get_provider.assert_called_once_with("openrouter")
+        record_usage.assert_called_once()
+        self.assertEqual(record_usage.call_args.kwargs["provider"], "openrouter")
+        self.assertEqual(record_usage.call_args.kwargs["model"], "openrouter-model")
 
 
 class Test_MWebFeedConfig(TestCase):

--- a/newsblur_web/docker_local_settings.py
+++ b/newsblur_web/docker_local_settings.py
@@ -152,6 +152,7 @@ ANTHROPIC_API_KEY = "sk-ant-XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
 GOOGLE_GEMINI_API_KEY = "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
 ASK_AI_MODEL = "opus"  # Options: opus, gpt-5.2, gemini-3, grok-4.1
 BRIEFING_MODEL = "haiku"  # Options: haiku, gpt-5-mini, gemini-flash-lite, grok-4.1-fast
+WEBFEED_MODEL = "haiku"  # Options: haiku, gpt-5-mini, gemini-flash-lite, grok-4.1-fast
 
 # Furthermore, you can connect to any OpenAI-compatible provider (OpenRouter,
 # local inference etc.) by setting BRIEFING_MODELS and/or ASK_AI_MODELS.

--- a/newsblur_web/docker_local_settings.py
+++ b/newsblur_web/docker_local_settings.py
@@ -153,6 +153,10 @@ GOOGLE_GEMINI_API_KEY = "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
 ASK_AI_MODEL = "opus"  # Options: opus, gpt-5.2, gemini-3, grok-4.1
 BRIEFING_MODEL = "haiku"  # Options: haiku, gpt-5-mini, gemini-flash-lite, grok-4.1-fast
 
+# Furthermore, you can connect to any OpenAI-compatible provider (OpenRouter,
+# local inference etc.) by setting BRIEFING_MODELS and/or ASK_AI_MODELS.
+# See apps/ask_ai/tests.py for examples.
+
 # ===========
 # = Logging =
 # ===========


### PR DESCRIPTION
This PR allows configuring alternative LLM providers (such as OpenRouter or local inference) for:

- Ask AI.
- Daily Briefing.
- Webfeed parsing.

Other AI features would require larger changes, as they are not using the `LLMProvider` class and registry.

More details in individual commit messages.

Samuel, do you agree with the intent? Are there things you would have preferred to see done differently, in this PR or a future one?