### PR TITLE
Add redis lock to premium pricing migration tasks

### DIFF
--- a/apps/profile/models.py
+++ b/apps/profile/models.py
@@ -3788,6 +3788,23 @@ class Profile(models.Model):
         if not preview:
             MSentEmail.record(receiver_user_id=self.user.pk, email_type="premium_pricing_upgrade")
 
+    @staticmethod
+    def _acquire_pricing_lock(name):
+        """Acquire a short-lived redis lock so only one beat scheduler runs a pricing-migration
+        task at a time (all three htask-work hosts run their own celery beat). Returns the held
+        lock (release it when done), the string "skip" if another runner already holds it, or None
+        if redis is unavailable (caller proceeds without locking rather than never running). The
+        30-minute timeout releases the lock automatically if a run crashes (apps/profile/models.py)."""
+        try:
+            r = redis.Redis(connection_pool=settings.REDIS_STATISTICS_POOL)
+            lock = r.lock(name, timeout=60 * 30)
+            if lock.acquire(blocking=False):
+                return lock
+            return "skip"
+        except Exception as e:
+            logging.debug(" ---> Pricing migration lock unavailable (%s); proceeding without it" % e)
+            return None
+
     @classmethod
     def run_premium_pricing_migration(cls, dry_run=False, limit=None, only_username=None):
         """Nightly campaign: move grandfathered $12/$24 premium subscribers to the $36 rate as
@@ -3795,6 +3812,12 @@ class Profile(models.Model):
         the existing next renewal, no charge now); PayPal subscriptions get an approval-link
         email. Idempotent via the PremiumPricingMigration tracking row. dry_run/limit/only_username
         exist so this can be exercised from the Django shell for testing (apps/profile/tasks.py)."""
+        lock = None
+        if not dry_run:
+            lock = cls._acquire_pricing_lock("lock:premium_pricing_migration")
+            if lock == "skip":
+                logging.debug(" ---> Premium pricing migration already running elsewhere; skipping")
+                return 0
         now = datetime.datetime.now()
         window_start = now + datetime.timedelta(hours=48)
         window_end = now + datetime.timedelta(hours=72)
@@ -3880,6 +3903,11 @@ class Profile(models.Model):
             " ---> Premium pricing migration processed %s users%s"
             % (processed, " (dry-run)" if dry_run else "")
         )
+        if lock and lock != "skip":
+            try:
+                lock.release()
+            except Exception:
+                pass
         return processed
 
     @staticmethod
@@ -3909,6 +3937,10 @@ class Profile(models.Model):
         when auto-renew is off. Records resubscribes for cancelled users so we can judge the PayPal
         experiment. Runs daily, so the cancel window is sized a little above the daily interval to
         guarantee we cancel before PayPal's next_billing_time without acting too early."""
+        lock = cls._acquire_pricing_lock("lock:premium_pricing_reconcile")
+        if lock == "skip":
+            logging.debug(" ---> Premium pricing reconciliation already running elsewhere; skipping")
+            return 0
         now = datetime.datetime.now()
         now_utc = datetime.datetime.utcnow()
         target_paypal_plan = Profile.plan_to_paypal_plan_id("premium")
@@ -3996,6 +4028,11 @@ class Profile(models.Model):
                 row.resubscribed_provider = resub.payment_provider
                 row.save()
 
+        if lock and lock != "skip":
+            try:
+                lock.release()
+            except Exception:
+                pass
         return emailed.count()
 
     def autologin_url(self, next=None):

--- a/apps/profile/test_profile.py
+++ b/apps/profile/test_profile.py
@@ -731,6 +731,11 @@ class Test_PremiumPricingMigration(TestCase):
         self.profile.premium_expire = datetime.datetime.now() + datetime.timedelta(hours=60)
         self.profile.stripe_id = "cus_pricingmig"
         self.profile.save()
+        # Default the redis lock to "proceed without lock" so tests don't depend on a live redis;
+        # the dedicated lock tests override this to exercise the "skip" path.
+        lock_patch = patch.object(Profile, "_acquire_pricing_lock", return_value=None)
+        lock_patch.start()
+        self.addCleanup(lock_patch.stop)
 
     def _add_payment(self, amount, days_ago=10, provider="stripe", refunded=None, user=None):
         return PaymentHistory.objects.create(
@@ -1091,3 +1096,30 @@ class Test_PremiumPricingMigration(TestCase):
 
         row.refresh_from_db()
         self.assertEqual(row.status, "upgraded")
+
+    # --- Redis lock (single-runner across the 3 beat schedulers) -------------
+
+    @patch.object(Profile, "switch_stripe_subscription", return_value=True)
+    @patch.object(Profile, "_acquire_pricing_lock", return_value="skip")
+    def test_run_skips_when_lock_held(self, mock_lock, mock_switch):
+        from apps.profile.models import PremiumPricingMigration
+
+        self._add_payment(24)
+        result = Profile.run_premium_pricing_migration(only_username="pricingmig")
+
+        self.assertEqual(result, 0)
+        mock_switch.assert_not_called()
+        self.assertFalse(PremiumPricingMigration.objects.filter(user=self.user).exists())
+
+    @patch.object(Profile, "cancel_premium_paypal")
+    @patch.object(Profile, "_acquire_pricing_lock", return_value="skip")
+    def test_reconcile_skips_when_lock_held(self, mock_lock, mock_cancel):
+        row = self._emailed_row()
+        self._add_payment(36, days_ago=0)
+
+        result = Profile.reconcile_premium_pricing_migration()
+
+        self.assertEqual(result, 0)
+        mock_cancel.assert_not_called()
+        row.refresh_from_db()
+        self.assertEqual(row.status, "emailed")  # untouched


### PR DESCRIPTION
All three `htask-work` hosts run their own embedded celery beat, so the nightly `premium-pricing-migration` and `reconcile-premium-pricing-migration` tasks can fire concurrently. This wraps both in a short-lived redis lock (`REDIS_STATISTICS_POOL`, 30-minute auto-expiry) so only one runner proceeds at a time — closing the small race where a user could receive a duplicate email under simultaneous fires.

If redis is unavailable the task proceeds without the lock (rather than never running); dry-run skips the lock entirely. Adds tests for the skip path on both tasks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)