### PR TITLE
Add awaiting-charge + $12/$24 upgrade splits to pricing migration chart

### DIFF
--- a/apps/monitor/views/newsblur_users.py
+++ b/apps/monitor/views/newsblur_users.py
@@ -137,6 +137,26 @@ class Users(View):
                 set_default=True,
                 expiration_sec=expiration_sec,
             ),
+            # Switched to $36 and emailed, but the renewal charge hasn't landed yet (in-flight).
+            "premium_pricing_awaiting_charge": MStatistics.get(
+                "munin:users_premium_pricing_awaiting_charge",
+                lambda: PremiumPricingMigration.objects.filter(status="emailed").count(),
+                set_default=True,
+                expiration_sec=expiration_sec,
+            ),
+            # Confirmed upgrades split by the old grandfathered rate.
+            "premium_pricing_upgrades_12": MStatistics.get(
+                "munin:users_premium_pricing_upgrades_12",
+                lambda: PremiumPricingMigration.objects.filter(status="upgraded", old_amount=12).count(),
+                set_default=True,
+                expiration_sec=expiration_sec,
+            ),
+            "premium_pricing_upgrades_24": MStatistics.get(
+                "munin:users_premium_pricing_upgrades_24",
+                lambda: PremiumPricingMigration.objects.filter(status="upgraded", old_amount=24).count(),
+                set_default=True,
+                expiration_sec=expiration_sec,
+            ),
         }
         chart_name = "users"
         chart_type = "counter"

--- a/docker/grafana/dashboards/newsblur_dashboard.json
+++ b/docker/grafana/dashboards/newsblur_dashboard.json
@@ -17276,6 +17276,33 @@
           "expr": "users{category=\"premium_pricing_would_cancel_paypal\"}",
           "legendFormat": "PayPal would-cancel (shadow)",
           "refId": "E"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "U1-fPO3Mk"
+          },
+          "expr": "users{category=\"premium_pricing_awaiting_charge\"}",
+          "legendFormat": "Switched, awaiting charge",
+          "refId": "F"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "U1-fPO3Mk"
+          },
+          "expr": "users{category=\"premium_pricing_upgrades_12\"}",
+          "legendFormat": "Upgrades ($12 -> $36)",
+          "refId": "G"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "U1-fPO3Mk"
+          },
+          "expr": "users{category=\"premium_pricing_upgrades_24\"}",
+          "legendFormat": "Upgrades ($24 -> $36)",
+          "refId": "H"
         }
       ],
       "title": "Premium Pricing Migration ($12/$24 -> $36)",


### PR DESCRIPTION
Adds three series to the Premium Pricing Migration panel: 'Switched, awaiting charge' (the `emailed` in-flight bucket), and upgrades split into $12->$36 and $24->$36.

🤖 Generated with [Claude Code](https://claude.com/claude-code)