### PR TITLE
Fix get_subdomain() redirect loop on apex domains

### DIFF
--- a/apps/reader/views.py
+++ b/apps/reader/views.py
@@ -174,10 +174,13 @@ RIVER_SLOWDOWN_USERS = []
 
 
 def get_subdomain(request):
+    if hasattr(request, "subdomain"):
+        return request.subdomain
     host = request.META.get("HTTP_HOST")
     if host and host.count(".") >= 2:
         return host.split(".")[0]
     else:
+        return None
         return None
 
 


### PR DESCRIPTION
## Problem

`get_subdomain()` in `apps/reader/views.py` naively splits the hostname on dots and returns the first segment. For apex domains like `newsblur.yourdomain.com` (which contain 2+ dots), it incorrectly returns `newsblur` as a subdomain. Since `newsblur` isn't in `ALLOWED_SUBDOMAINS` and doesn't match any username, it redirects to the same URL — causing an infinite redirect loop.

## Fix

Use `request.subdomain` from the `SubdomainMiddleware` instead, which properly parses subdomains against the `Site` domain and returns `None` for apex domains. Falls back to the old logic only when the middleware hasn't set the attribute.