### PR TITLE
Fix `getNextNonEmptyFolder` crash

### DIFF
--- a/clients/android/NewsBlur/app/src/main/java/com/newsblur/util/SessionDataSource.kt
+++ b/clients/android/NewsBlur/app/src/main/java/com/newsblur/util/SessionDataSource.kt
@@ -144,6 +144,12 @@ class SessionDataSource private constructor(
      * until it finds a non empty folder or it will get to the end of the folder list.
      */
     private fun getNextNonEmptyFolder(folderName: String): Pair<String, List<Feed>>? =
+        getNextNonEmptyFolder(folderName, startFolderName = folderName)
+
+    private fun getNextNonEmptyFolder(
+        folderName: String,
+        startFolderName: String,
+    ): Pair<String, List<Feed>>? =
         with(folders.indexOf(folderName)) {
             val nextIndex =
                 if (this == folders.size - 1) {
@@ -161,14 +167,19 @@ class SessionDataSource private constructor(
                     null
                 }
 
-            if (nextFolderName == null || nextFolderName == folderName) {
+            // Stop on a full wrap back to the folder we started from, otherwise an all-empty
+            // unread filter walks forever.
+            if (nextFolderName == null ||
+                nextFolderName == folderName ||
+                nextFolderName == startFolderName
+            ) {
                 return null
             }
 
             val feeds = foldersChildrenMap[nextFolderName]
             if (feeds.isNullOrEmpty() || !feeds.hasNextUnreadTarget()) {
                 // try and get the next non empty folder name
-                getNextNonEmptyFolder(nextFolderName)
+                getNextNonEmptyFolder(nextFolderName, startFolderName)
             } else {
                 nextFolderName to feeds
             }

--- a/clients/android/NewsBlur/app/src/test/java/com/newsblur/SessionDataSourceTest.kt
+++ b/clients/android/NewsBlur/app/src/test/java/com/newsblur/SessionDataSourceTest.kt
@@ -160,6 +160,32 @@ class SessionDataSourceTest {
         } ?: Assert.fail("Next unread folder session was null")
     }
 
+    /**
+     * When every folder has no unread under the intelligence filter, peeking the next
+     * session must return null instead of wrapping the folder list forever.
+     */
+    @Test
+    fun `next unread session is null when no folder has unread feeds`() {
+        val feed20 = createFeed("20")
+        val session = Session(FeedSet.singleFeed("20"), "F2", feed20)
+        val sessionDs =
+            SessionDataSource(
+                session,
+                folders,
+                listOf(
+                    emptyList(),
+                    listOf(feed20, createFeed("21"), createFeed("22")),
+                    listOf(createFeed("30")),
+                    emptyList(),
+                    listOf(createFeed("50"), createFeed("51")),
+                ),
+                StateFilter.ALL,
+                emptySet(),
+            )
+
+        Assert.assertNull(sessionDs.peekNextSession())
+    }
+
     @Test
     fun `next unread feed session falls through to next unread folder`() {
         val feed20 = createFeed("20", neutralCount = 1)


### PR DESCRIPTION
Thanks for making NewsBlur!

A couple of hours ago I hit a crash on my Android phone.

[NewsBlur-Crash-Logs.txt](https://github.com/user-attachments/files/30611830/NewsBlur-Crash-Logs.txt)

I was going to open an issue, but the crash looked fun (stack overflows are everyone's favorite after all!), so I figured I'd try fixing it myself. Note: I know pretty much no Kotlin.

The production trace is obfuscated, so I built a debug APK and reproduced it on Waydroid. A few log statements later, the bug showed up in `getNextNonEmptyFolder`.

When no folder has any unread feeds under the current filter, that function never stops walking the folder list. It wraps forever and eventually blows the stack.

The fix keeps the public shape the same: the original function now calls an overload that also takes `startFolderName`. It still walks the folders, but once it comes back around to the folder it started from, it returns `null`. I also added a unit test that used to throw a `StackOverflowError` before this change.

I tried to keep the patch small. Longer term, I'd personally drop the recursion here. I'm not deep enough in Kotlin to speak to every language-level detail, but from a normal programming point of view this burns stack for no real benefit, I believe. A plain loop would be clearer and safer.