### PR TITLE
Allow operators to opt out of proprietary fonts

### DIFF
--- a/newsblur_web/settings.py
+++ b/newsblur_web/settings.py
@@ -98,6 +98,7 @@ ALLOWED_HOSTS = ["*"]
 AUTO_PREMIUM_NEW_USERS = True
 AUTO_ENABLE_NEW_USERS = True
 ENFORCE_SIGNUP_CAPTCHA = False
+USE_LICENSED_FONTS = True  # Load Whitney/Gotham/etc. from cloud.typography.com (paid, domain-locked)
 ENABLE_PUSH = True
 PAYPAL_TEST = False
 DATA_UPLOAD_MAX_MEMORY_SIZE = 5242880  # 5 MB

--- a/templates/base.html
+++ b/templates/base.html
@@ -176,14 +176,12 @@
     NEWSBLUR.app = {};
       </script>
       {% include_stylesheets "common" %}
-      {% if debug_assets %}
-        <link rel="stylesheet"
-              type="text/css"
-              href="https://cloud.typography.com/6565292/731824/css/fonts.css" />
-      {% else %}
-        <link rel="stylesheet"
-              type="text/css"
-              href="https://cloud.typography.com/6565292/711824/css/fonts.css" />
+      {% if USE_LICENSED_FONTS %}
+        {% if debug_assets %}
+          <link rel="stylesheet" type="text/css" href="https://cloud.typography.com/6565292/731824/css/fonts.css" />
+        {% else %}
+          <link rel="stylesheet" type="text/css" href="https://cloud.typography.com/6565292/711824/css/fonts.css" />
+        {% endif %}
       {% endif %}
     </head>
     <body class="{% block bodyclass %}{% endblock %} {% if user.is_staff %}NB-staff{% endif %} {% if user_profile.is_premium %}NB-premium{% endif %}">


### PR DESCRIPTION
When I set up my self-hosted NewsBlur my page would stall out for 2 minutes on a blocking font include.

It appears that if my domain isn't in typography.com's allowlist for the paid fonts, that's what happens.

This PR allows operators to disable those fonts. Everything seems to load / render fine without them.