### PR TITLE
Ensuring Docker Builds work on Linux

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,8 +52,8 @@ services:
 
   imageproxy:
     container_name: newsblur_imageproxy
-    # image: ghcr.io/willnorris/imageproxy:latest # Enable if you don't need arm64 and want the original imageproxy
-    image: yusukeito/imageproxy:v0.11.2 # Enable if you want arm64
+    image: ghcr.io/willnorris/imageproxy:latest # Multi-arch (amd64/arm64); use this unless it breaks on your platform
+    # image: yusukeito/imageproxy:v0.11.2 # arm64-only fork; use if the image above doesn't work for you
     user: "${CURRENT_UID:-1000}:${CURRENT_GID:-1000}"
     entrypoint: /app/imageproxy -addr 0.0.0.0:8088 -cache /tmp/imageproxy -verbose
     restart: unless-stopped
@@ -126,13 +126,17 @@ services:
   newsblur_db_elasticsearch:
     container_name: newsblur_db_elasticsearch
     image: docker.elastic.co/elasticsearch/elasticsearch:8.17.0
+    # Matches the image's built-in "elasticsearch" user (uid 1000, gid 0). Without this,
+    # Docker auto-creates the bind-mounted data dir as root on first run, and the
+    # non-root elasticsearch process can't obtain its node lock inside it.
+    user: "1000:0"
     mem_limit: 2g
     mem_reservation: 512m
     restart: unless-stopped
     environment:
       - discovery.type=single-node
-      - "ES_JAVA_OPTS=-Xms384m -Xmx384m -XX:UseSVE=0"
-      - "CLI_JAVA_OPTS=-XX:UseSVE=0"
+      - "ES_JAVA_OPTS=-Xms384m -Xmx384m -XX:+IgnoreUnrecognizedVMOptions -XX:UseSVE=0"
+      - "CLI_JAVA_OPTS=-XX:+IgnoreUnrecognizedVMOptions -XX:UseSVE=0"
       - cluster.routing.allocation.disk.threshold_enabled=false
       - xpack.security.enabled=false
       - bootstrap.memory_lock=false
@@ -198,6 +202,11 @@ services:
     container_name: newsblur_haproxy
     image: haproxy:latest
     restart: unless-stopped
+    # host.docker.internal is provided automatically on Docker Desktop (Mac/Windows) but
+    # not on native Linux Docker Engine. This makes the camera_monitor backend resolvable
+    # on Linux too, instead of just failing its health check.
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     depends_on:
       - nginx
       - newsblur_web

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -150,22 +150,11 @@ services:
     mem_limit: 2g
     mem_reservation: 512m
     restart: unless-stopped
-    # -XX:UseSVE=0 disables an ARM SVE optimization and is only a valid JVM
-    # flag on arm64; passing it unconditionally crashes Elasticsearch's
-    # startup on x86_64 with "Unrecognized VM option". Detect the running
-    # container's actual architecture at boot (covers QEMU-emulated
-    # containers too, not just the host's reported arch) and only add the
-    # flag where it applies, instead of blanket-suppressing all unrecognized
-    # JVM options as a workaround.
-    entrypoint: >
-      /bin/bash -c '
-        arch="$$(uname -m)";
-        if [[ "$$arch" == "aarch64" || "$$arch" == "arm64" ]]; then
-          export ES_JAVA_OPTS="$$ES_JAVA_OPTS -XX:UseSVE=0";
-          export CLI_JAVA_OPTS="$$CLI_JAVA_OPTS -XX:UseSVE=0";
-        fi;
-        exec /bin/tini -- /usr/local/bin/docker-entrypoint.sh eswrapper
-      '
+    # See docker/elasticsearch/entrypoint.sh: only adds the ARM-only
+    # -XX:UseSVE=0 JVM flag when actually running on arm64, instead of
+    # hardcoding it (crashes on x86_64) or blanket-suppressing all
+    # unrecognized JVM options as a workaround.
+    entrypoint: ["/bin/bash", "/entrypoint.sh"]
     environment:
       - discovery.type=single-node
       - "ES_JAVA_OPTS=-Xms384m -Xmx384m"
@@ -177,6 +166,7 @@ services:
       - 9200:9200
       - 9300:9300
     volumes:
+      - ./docker/elasticsearch/entrypoint.sh:/entrypoint.sh:ro
       - ./docker/volumes/elasticsearch:/usr/share/elasticsearch/data
       - ./config/elasticsearch/elasticsearch.yml:/usr/share/elasticsearch/config/elasticsearch.yml
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -123,20 +123,52 @@ services:
   #     - ./docker/volumes/redis_prod:/data
   #   command: redis-server /etc/redis/redis.conf --port 6579
 
+  # One-shot init step: chowns the bind-mounted data dir to the image's
+  # built-in elasticsearch user (uid 1000, gid 0) before Elasticsearch starts.
+  # Docker auto-creates a missing bind-mount host directory as root, and this
+  # image's entrypoint never chowns its own data dir on boot - it always execs
+  # directly as its non-root user. Docker Desktop's bind-mount layer papers
+  # over the resulting ownership mismatch; native Linux Docker Engine enforces
+  # real UID permissions, so a genuinely fresh clone fails there with an
+  # AccessDeniedException obtaining the node lock. Idempotent and harmless on
+  # every host, including Desktop, so it doesn't need an OS check.
+  newsblur_db_elasticsearch_permissions:
+    container_name: newsblur_db_elasticsearch_permissions
+    image: alpine:latest
+    command: chown -R 1000:0 /usr/share/elasticsearch/data
+    volumes:
+      - ./docker/volumes/elasticsearch:/usr/share/elasticsearch/data
+    restart: "no"
+
   newsblur_db_elasticsearch:
     container_name: newsblur_db_elasticsearch
     image: docker.elastic.co/elasticsearch/elasticsearch:8.17.0
-    # Matches the image's built-in "elasticsearch" user (uid 1000, gid 0). Without this,
-    # Docker auto-creates the bind-mounted data dir as root on first run, and the
-    # non-root elasticsearch process can't obtain its node lock inside it.
-    user: "1000:0"
+    user: "1000:0" # the image's own built-in user; not host-dependent
+    depends_on:
+      newsblur_db_elasticsearch_permissions:
+        condition: service_completed_successfully
     mem_limit: 2g
     mem_reservation: 512m
     restart: unless-stopped
+    # -XX:UseSVE=0 disables an ARM SVE optimization and is only a valid JVM
+    # flag on arm64; passing it unconditionally crashes Elasticsearch's
+    # startup on x86_64 with "Unrecognized VM option". Detect the running
+    # container's actual architecture at boot (covers QEMU-emulated
+    # containers too, not just the host's reported arch) and only add the
+    # flag where it applies, instead of blanket-suppressing all unrecognized
+    # JVM options as a workaround.
+    entrypoint: >
+      /bin/bash -c '
+        arch="$$(uname -m)";
+        if [[ "$$arch" == "aarch64" || "$$arch" == "arm64" ]]; then
+          export ES_JAVA_OPTS="$$ES_JAVA_OPTS -XX:UseSVE=0";
+          export CLI_JAVA_OPTS="$$CLI_JAVA_OPTS -XX:UseSVE=0";
+        fi;
+        exec /bin/tini -- /usr/local/bin/docker-entrypoint.sh eswrapper
+      '
     environment:
       - discovery.type=single-node
-      - "ES_JAVA_OPTS=-Xms384m -Xmx384m -XX:+IgnoreUnrecognizedVMOptions -XX:UseSVE=0"
-      - "CLI_JAVA_OPTS=-XX:+IgnoreUnrecognizedVMOptions -XX:UseSVE=0"
+      - "ES_JAVA_OPTS=-Xms384m -Xmx384m"
       - cluster.routing.allocation.disk.threshold_enabled=false
       - xpack.security.enabled=false
       - bootstrap.memory_lock=false

--- a/docker/elasticsearch/entrypoint.sh
+++ b/docker/elasticsearch/entrypoint.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+# entrypoint.sh
+#
+# -XX:UseSVE=0 disables an ARM SVE optimization and is only a valid JVM flag
+# on arm64; passing it unconditionally crashes Elasticsearch's startup on
+# x86_64 with "Unrecognized VM option". Only add it when actually running on
+# arm64/aarch64, checking the container's own architecture (not the host's)
+# so this also works correctly for emulated containers.
+
+arch="$(uname -m)"
+if [[ "$arch" == "aarch64" || "$arch" == "arm64" ]]; then
+  export ES_JAVA_OPTS="$ES_JAVA_OPTS -XX:UseSVE=0"
+  export CLI_JAVA_OPTS="$CLI_JAVA_OPTS -XX:UseSVE=0"
+fi
+
+exec /bin/tini -- /usr/local/bin/docker-entrypoint.sh eswrapper

--- a/docker/haproxy/haproxy.docker-compose.cfg
+++ b/docker/haproxy/haproxy.docker-compose.cfg
@@ -137,7 +137,7 @@ backend gunicorn
 backend camera_monitor
     option httpchk GET /api/status
     http-check expect status 200
-    server camera_monitor host.docker.internal:8765 check inter 5000ms
+    server camera_monitor host.docker.internal:8765 check inter 5000ms resolvers docker init-addr last,libc,none
 
 backend postgres
     server db_postgres newsblur_db_postgres:5432 check inter 2000ms resolvers docker init-addr last,libc,none


### PR DESCRIPTION

Docker Desktop for Mac resolves `host.docker.internal` automatically and its bind-mount layer doesn't enforce real uid/gid ownership. Plain Docker Engine on Linux does neither: bind mounts are real directories with real permission bits, and nothing defines `host.docker.internal` unless you tell it to.

On a fresh clone, I found the stack breaks in four separate places. They all seem to be the product of designing this build on/for Mac. I've tried to make sure these changes will help NewsBlur run on Linux without breaking it on other operating systems.

While this pull request was prepared with the assistance of artificial work, this request and the changes associated with it have all been reviewed by me as well.

## 1. haproxy won't start at all

Every backend in `haproxy.docker-compose.cfg` has a fallback line so that if it can't resolve a hostname, it just disables that one backend instead of crashing. One backend, `camera_monitor`, is missing that line. Here's what happens with and without it:

```dockerfile
# as it is now:
[ALERT] (8) : 'server camera_monitor/camera_monitor' : could not resolve address 'host.docker.internal'.
[ALERT] (8) : Failed to initialize server(s) addr.
[WARNING] (1) : Failed to load worker (8) exited with code 1 (Exit)

# with the same fallback line the other backends already have:
[NOTICE] (8) : 'server camera_monitor/camera_monitor' : could not resolve address 'host.docker.internal', disabling server.
# haproxy keeps starting normally
```

Fix: add the same `resolvers docker init-addr last,libc,none` fallback the other backends already use.

## 2. `host.docker.internal` doesn't resolve on Linux

Confirmed directly:

```bash
$ docker run --rm alpine getent hosts host.docker.internal
(nothing, it doesn't resolve)

$ docker run --rm --add-host host.docker.internal:host-gateway alpine getent hosts host.docker.internal
172.17.0.1        host.docker.internal  host.docker.internal
```

Fix: add this to the `haproxy` service in `docker-compose.yml`:

```yaml
extra_hosts:
  - "host.docker.internal:host-gateway"
```

`host-gateway` resolves to the host's IP from inside the container, on every platform, so it's a no-op on Mac (Desktop already defines the name) and fills the gap on Linux. Per Docker's docs on [`--add-host`](https://docs.docker.com/reference/cli/docker/container/run/#add-host). Not verified on an actual Mac.

## 3. Elasticsearch crashes on boot: a JVM flag that only exists on ARM

`ES_JAVA_OPTS` had `-XX:UseSVE=0` hardcoded in:

```bash
$ docker run -e "ES_JAVA_OPTS=-Xms384m -Xmx384m -XX:UseSVE=0" ... elasticsearch:8.17.0
Unrecognized VM option 'UseSVE=0'
Error: Could not create the Java Virtual Machine.
```

This is a hardware issue: `-XX:UseSVE=0` is ARM-only, so this would crash the same way on any x86_64 host, Intel Mac included.

Fix: check the container's actual architecture at boot and only add the flag when it's really arm64, in `docker/elasticsearch/entrypoint.sh`, following the same pattern `docker/postgres/entrypoint.sh` already used previously in this project.

`docker/elasticsearch/entrypoint.sh`:

```bash
#!/bin/bash
arch="$(uname -m)"
if [[ "$arch" == "aarch64" || "$arch" == "arm64" ]]; then
  export ES_JAVA_OPTS="$ES_JAVA_OPTS -XX:UseSVE=0"
  export CLI_JAVA_OPTS="$CLI_JAVA_OPTS -XX:UseSVE=0"
fi

exec /bin/tini -- /usr/local/bin/docker-entrypoint.sh eswrapper
```

`docker-compose.yml`:

```yaml
entrypoint: ["/bin/bash", "/entrypoint.sh"]
volumes:
  - ./docker/elasticsearch/entrypoint.sh:/entrypoint.sh:ro
```

**Considered, but rejected:** `-XX:+IgnoreUnrecognizedVMOptions`: it would silently swallow any bad flag going forward, not just this one.

`CLI_JAVA_OPTS` is load-bearing: `bin/elasticsearch` sources `elasticsearch-cli`, which reads `CLI_JAVA_OPTS` for its own small bootstrap JVM before launching the real server, so both env vars need the flag.

The script checks two spellings, `aarch64` and `arm64`, because the same physical chip reports differently depending on the OS: Linux's `uname -m` says `aarch64`, macOS's says `arm64`.

## 4. Elasticsearch crashes on boot: the data folder ends up owned by root

On a truly fresh clone, the `docker/volumes/elasticsearch` folder doesn't exist yet. Docker creates it for you when the container starts, but it creates it as root:

```bash
$ ls -lan /tmp/es-repro-fresh
drwxr-xr-x 2 0 0 40 ... .

$ docker run -v /tmp/es-repro-fresh:/usr/share/elasticsearch/data ... elasticsearch:8.17.0
"error.message":"failed to obtain node locks, tried [/usr/share/elasticsearch/data]; ..."
"...Caused by: java.nio.file.AccessDeniedException: /usr/share/elasticsearch/data/node.lock..."
```

Elasticsearch's container runs as a non-root user (uid 1000) and never chowns its own data folder. Docker Desktop's bind-mount layer doesn't enforce real uid/gid, so this never surfaces there. On native Linux the bind mount is a directory with real permission bits, so a root-owned folder genuinely can't be written by uid 1000.

Fix: a tiny one-off container that runs before Elasticsearch and fixes the folder's ownership.

```yaml
newsblur_db_elasticsearch_permissions:
  container_name: newsblur_db_elasticsearch_permissions
  image: alpine:latest
  command: chown -R 1000:0 /usr/share/elasticsearch/data
  volumes:
    - ./docker/volumes/elasticsearch:/usr/share/elasticsearch/data
  restart: "no"
```

Then make Elasticsearch wait for it to finish:

```yaml
depends_on:
  newsblur_db_elasticsearch_permissions:
    condition: service_completed_successfully
```

This runs every time you start the stack, but it's cheap and a no-op if the ownership is already correct, so it doesn't hurt anything on Mac either. Result:

```bash
$ curl localhost:9200/_cluster/health
{"cluster_name":"newsblur-local","status":"green", ...}
```

## 5. imageproxy crashes: wrong image for the CPU

`imageproxy` was pinned to `yusukeito/imageproxy:v0.11.2`, which is an ARM-only build:

```bash
$ docker run yusukeito/imageproxy:v0.11.2 ...
WARNING: The requested image's platform (linux/arm64) does not match the detected host platform (linux/amd64/v4)
exec /app/imageproxy: exec format error
```

Fix: use `ghcr.io/willnorris/imageproxy:latest` instead, a proper multi-arch image:

```bash
$ docker run --entrypoint /app/imageproxy ghcr.io/willnorris/imageproxy:latest -addr 0.0.0.0:8088 ...
# starts fine, no crash
```

**This was already fixed once, then broken again by an unrelated commit.** On 2022-05-25 (`656479a876`), the default was `ghcr.io/willnorris/imageproxy:latest`, the multi-arch image, with the arm64-only build left commented out as an opt-in. On 2022-12-26, commit [`1065c964fd`](https://github.com/samuelclay/NewsBlur/commit/1065c964fd18901f6b0d74638746292001f6116c) ("Fixing elasticsearch to allow consul to assume its OK") flipped it back to the arm64-only image as the default.

Two things I couldn't verify myself:

- The ARM branch of the fix in #3 looks right on paper, but I don't have an arm64 machine to actually run it on.
- The claim in #2 that `host-gateway` is harmless on Mac comes from Docker's own docs, not from testing on an actual Mac.